### PR TITLE
Ensure column is pinned to 0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,9 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.testing.cwd": "${workspaceFolder}",
-    "python.formatting.provider": "black",
-    "editor.formatOnSave": true
+    "python.formatting.provider": "none",
+    "editor.formatOnSave": true,
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    }
 }

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -159,7 +159,7 @@ def _parse_output_using_regex(
             data = match.groupdict()
             position = lsp.Position(
                 line=max([int(data["line"]) - line_offset, 0]),
-                character=int(data["column"]) - col_offset,
+                character=max([int(data["column"]) - col_offset, 0]),
             )
             diagnostic = lsp.Diagnostic(
                 range=lsp.Range(


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-flake8/issues/141

We have tests to validate standard flake8. We need this change to ensure some of the plugins don't fail. Authors of some plugins use 0 based column index when flake8 themselves use 1 based column index. From the LSP server we can;t differentiate which plugin generated the error, so we masure that the column value does not become negative.