### PR TITLE
Add code action for E242

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -254,7 +254,7 @@ def code_action(params: lsp.CodeActionParams) -> List[lsp.CodeAction]:
     return code_actions
 
 
-@QUICK_FIXES.quick_fix(codes=["E241", "E271", "E273", "E274", "E275"])
+@QUICK_FIXES.quick_fix(codes=["E241", "E242", "E271", "E273", "E274", "E275"])
 def fix_format(
     _document: workspace.Document, diagnostics: List[lsp.Diagnostic]
 ) -> List[lsp.CodeAction]:

--- a/src/test/python_tests/test_code_actions.py
+++ b/src/test/python_tests/test_code_actions.py
@@ -20,16 +20,24 @@ LINTER = utils.get_server_info_defaults()["name"]
     ("code", "contents", "command"),
     [
         (
-            "E271",
-            "from collections import    (namedtuple, defaultdict)",
+            "E241",
+            "x = [1,   2]",
             {
                 "title": f"{LINTER}: Run document formatting",
                 "command": "editor.action.formatDocument",
             },
         ),
         (
-            "E241",
-            "x = [1,   2]",
+            "E242",
+            "a,	b = 1, 2",
+            {
+                "title": f"{LINTER}: Run document formatting",
+                "command": "editor.action.formatDocument",
+            },
+        ),
+        (
+            "E271",
+            "from collections import    (namedtuple, defaultdict)",
             {
                 "title": f"{LINTER}: Run document formatting",
                 "command": "editor.action.formatDocument",


### PR DESCRIPTION
close https://github.com/microsoft/vscode-flake8/issues/29

This PR adds the rule for detecting `tab after ','` (`E242`)
