### PR TITLE
Add quick fix for flake8 error E272

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -254,7 +254,7 @@ def code_action(params: lsp.CodeActionParams) -> List[lsp.CodeAction]:
     return code_actions
 
 
-@QUICK_FIXES.quick_fix(codes=["E241", "E242", "E271", "E273", "E274", "E275"])
+@QUICK_FIXES.quick_fix(codes=["E241", "E242", "E271", "E272", "E273", "E274", "E275"])
 def fix_format(
     _document: workspace.Document, diagnostics: List[lsp.Diagnostic]
 ) -> List[lsp.CodeAction]:

--- a/src/test/python_tests/test_code_actions.py
+++ b/src/test/python_tests/test_code_actions.py
@@ -44,6 +44,14 @@ LINTER = utils.get_server_info_defaults()["name"]
             },
         ),
         (
+            "E272",
+            "from collections import (namedtuple, defaultdict)     ",
+            {
+                "title": f"{LINTER}: Run document formatting",
+                "command": "editor.action.formatDocument",
+            },
+        ),
+        (
             "E273",
             "x = 1 in\t[1, 2, 3]",
             {


### PR DESCRIPTION
 Add quick fix for when flake8 triggers the "multiple spaces before keyword" warning #39 