### PR TITLE
Removed python 3.7 from tests action

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-flake8/issues/219, removed python 3.7 from test actions for vscode-flake8