### PR TITLE
Use global settings for `ignorePatterns` default

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -463,7 +463,7 @@ def _get_global_defaults():
                 "W": "Warning",
             },
         ),
-        "ignorePatterns": [],
+        "ignorePatterns": GLOBAL_SETTINGS.get("ignorePatterns", []),
         "importStrategy": GLOBAL_SETTINGS.get("importStrategy", "useBundled"),
         "showNotifications": GLOBAL_SETTINGS.get("showNotifications", "off"),
     }


### PR DESCRIPTION
Fixes #326.

## Changes
- Update `_get_global_defaults` to check `GLOBAL_SETTINGS` for default value of the `ignorePatterns` setting
- Otherwise, user settings are not respected for non-workspace files

I'm not sure if there was any particular reason the settings were being ignored: I could not find any rationale in #147/#239 or microsoft/vscode-mypy#179 and microsoft/vscode-mypy#182 indicating such, so I am assuming this was an oversight.

## Testing
1. Add a pattern to be ignored to the user settings for `flake8.ignorePatterns`, e.g. `"*.py"`
2. Open a non-workspace file matching the pattern that has a linting issue
3. Observe the file is properly ignored (extension output should say "Skipping file due to `flake8.ignorePatterns` match")