### PR TITLE
Update action labels

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -16,6 +16,6 @@ jobs:
       - name: 'PR impact specified'
         uses: mheap/github-action-required-labels@v5
         with:
-          mode: exactly
+          mode: minimum
           count: 1
           labels: 'bug, debt, feature-request, no-changelog'


### PR DESCRIPTION
Extends #366 to update the requirements for PR labels (should be at least one, not _exactly_ one).