### PR TITLE
Sync with template: Fix duplicate server handlers on concurrent restarts

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -87,9 +87,9 @@ export async function restartServer(
         } catch (ex) {
             traceError(`Server: Stop failed: ${ex}`);
         }
-        _disposables.forEach((d) => d.dispose());
-        _disposables = [];
     }
+    _disposables.forEach((d) => d.dispose());
+    _disposables = [];
     updateStatus(undefined, LanguageStatusSeverity.Information, true);
 
     const newLSClient = await createServer(workspaceSetting, serverId, serverName, outputChannel, {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,6 +113,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 export async function deactivate(): Promise<void> {
     if (lsClient) {
-        await lsClient.stop();
+        try {
+            await lsClient.stop();
+        } catch (ex) {
+            traceError(`Server: Stop failed: ${ex}`);
+        }
     }
 }


### PR DESCRIPTION
- Move _disposables cleanup outside lsClient guard in restartServer() so disposables are always released, even when no previous client existed.
- Wrap lsClient.stop() in deactivate() with try/catch to prevent unhandled rejections during extension deactivation.

Source: microsoft/vscode-python-tools-extension-template#259