### PR TITLE
Add loading message and related issues section to triage workflow

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -23,7 +23,7 @@
 #
 # When a new issue is opened — or when a maintainer comments `/triage-issue` on an existing issue — analyze its root cause, check whether the same issue could affect other extensions built from the microsoft/vscode-python-tools-extension-template, and look for related open issues on the upstream flake8 repository (PyCQA/flake8). If applicable, suggest an upstream fix and surface relevant flake8 issues to the reporter.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"41860268a4d18b65b0b4f2055468d370c7b514ef6ee0f0b2a250a3299a0f8f00","compiler_version":"v0.47.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"ff7f98f4e84dc60af8616932fb1b722e5f2cff70645e1e0c75a54dd92b429cbc","compiler_version":"v0.47.5"}
 
 name: 'Issue Triage'
 'on':
@@ -908,6 +908,7 @@ jobs:
           GH_AW_WORKFLOW_ID: 'issue-triage'
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.agent.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
+          GH_AW_SAFE_OUTPUT_MESSAGES: '{"runStarted":"⏳ **Triage Issue Agent**: I will analyze this issue and determine if related issues exist in this repo, the upstream Python tool, or similar extensions. This may take a couple of minutes."}'
           GH_AW_GROUP_REPORTS: 'false'
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1068,6 +1069,7 @@ jobs:
     timeout-minutes: 15
     env:
       GH_AW_ENGINE_ID: 'copilot'
+      GH_AW_SAFE_OUTPUT_MESSAGES: '{"runStarted":"⏳ **Triage Issue Agent**: I will analyze this issue and determine if related issues exist in this repo, the upstream Python tool, or similar extensions. This may take a couple of minutes."}'
       GH_AW_WORKFLOW_ID: 'issue-triage'
       GH_AW_WORKFLOW_NAME: 'Issue Triage'
     outputs:

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -20,6 +20,8 @@ tools:
 network:
   allowed: []
 safe-outputs:
+  messages:
+    run-started: "⏳ **Triage Issue Agent**: I will analyze this issue and determine if related issues exist in this repo, the upstream Python tool, or similar extensions. This may take a couple of minutes."
   add-comment:
     max: 1
   noop:
@@ -46,6 +48,8 @@ This workflow is triggered in two ways:
 2. **On demand** when a maintainer posts a `/triage-issue` comment on an existing issue.
 
 If triggered by a comment, first verify the comment body is exactly `/triage-issue` (ignoring leading/trailing whitespace). If it is not, call the `noop` safe output and stop — do not process arbitrary comments.
+
+> **Note:** A loading message has already been posted on the issue when this workflow started, so the reporter knows analysis is in progress. You do not need to post a preliminary comment — go straight to your analysis.
 
 Your goals are:
 
@@ -101,6 +105,9 @@ Search the **vscode-flake8** repository for the relevant code. Look at:
 - The files mentioned or implied by the issue (error messages, file paths, setting names).
 - Recent commits or changes that might have introduced the problem.
 - Related open or closed issues that describe similar symptoms.
+- Related open pull requests that may address or be related to the problem.
+
+Keep track of any related issues and PRs you find — you will reference them in your analysis comment.
 
 Formulate a clear, concise explanation of the probable root cause.
 
@@ -141,6 +148,11 @@ Post a comment on the issue using the `add-comment` safe output. Structure your 
 #### Affected Code
 - **File(s):** `<file paths>`
 - **Area:** <TypeScript client / Python server / Build & CI / Configuration>
+
+#### Related Issues & Pull Requests
+<List related open or recently closed issues and PRs from this repository that describe similar symptoms or address the same problem. If none are found, omit this section.>
+
+- **#NNN** — <issue/PR title> — <one-sentence explanation of why it is related>
 
 #### Template Impact
 <One of the following:>


### PR DESCRIPTION
- Add run-started message so reporters see immediate feedback when the triage agent starts
- Add **Related Issues & Pull Requests** section to the analysis comment template
- Update agent instructions to search for related PRs during investigation