### PR TITLE
Use new python environments extension for resolving python interpreter

### DIFF
--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -2,11 +2,25 @@
 // Licensed under the MIT License.
 
 /* eslint-disable @typescript-eslint/naming-convention */
-import { commands, Disposable, Event, EventEmitter, Uri } from 'vscode';
+import { commands, Disposable, extensions, Event, EventEmitter, Uri } from 'vscode';
 import { traceError, traceLog } from './logging';
 import { PythonExtension, ResolvedEnvironment } from '@vscode/python-extension';
+import { PythonEnvironmentsAPI } from '../typings/pythonEnvironments';
 import { PYTHON_MAJOR, PYTHON_MINOR, PYTHON_VERSION } from './constants';
 import { getProjectRoot } from './utilities';
+
+const PYTHON_ENVIRONMENTS_EXTENSION_ID = 'ms-python.vscode-python-envs';
+
+async function getEnvironmentsExtensionAPI(): Promise<PythonEnvironmentsAPI | undefined> {
+    const extension = extensions.getExtension(PYTHON_ENVIRONMENTS_EXTENSION_ID);
+    if (!extension) {
+        return undefined;
+    }
+    if (!extension.isActive) {
+        await extension.activate();
+    }
+    return extension.exports as PythonEnvironmentsAPI;
+}
 
 export interface IInterpreterDetails {
     path?: string[];
@@ -64,15 +78,27 @@ async function refreshServerPython(): Promise<void> {
 
 export async function initializePython(disposables: Disposable[]): Promise<void> {
     try {
-        const api = await getPythonExtensionAPI();
+        // Prefer the Python Environments extension if it's available, as it provides a more comprehensive view of the available environments.
+        const envsApi = await getEnvironmentsExtensionAPI();
+        if (envsApi) {
+            disposables.push(
+                envsApi.onDidChangeEnvironment(async () => {
+                    await refreshServerPython();
+                }),
+            );
+            traceLog('Waiting for interpreter from Python Environments extension.');
+            await refreshServerPython();
+            return;
+        }
 
+        // Fall back to legacy ms-python.python extension API
+        const api = await getPythonExtensionAPI();
         if (api) {
             disposables.push(
                 api.environments.onDidChangeActiveEnvironmentPath(async () => {
                     await refreshServerPython();
                 }),
             );
-
             traceLog('Waiting for interpreter from Python extension.');
             await refreshServerPython();
         }
@@ -87,6 +113,18 @@ export async function resolveInterpreter(interpreter: string[]): Promise<Resolve
 }
 
 export async function getInterpreterDetails(resource?: Uri): Promise<IInterpreterDetails> {
+    // Prefer the Python Environments extension if it's available, as it provides a more comprehensive view of the available environments.
+    const envsApi = await getEnvironmentsExtensionAPI();
+    if (envsApi) {
+        const environment = await envsApi.getEnvironment(resource);
+        if (environment) {
+            const executablePath = environment.execInfo?.run?.executable ?? environment.environmentPath.fsPath;
+            traceLog(`Using Python interpreter from Python Environments extension: ${executablePath}`);
+            return { path: [executablePath], resource };
+        }
+        return { path: undefined, resource };
+    }
+    // Fall back to legacy ms-python.python extension API
     const api = await getPythonExtensionAPI();
     const environment = await api?.environments.resolveEnvironment(
         api?.environments.getActiveEnvironmentPath(resource),

--- a/src/typings/pythonEnvironments.d.ts
+++ b/src/typings/pythonEnvironments.d.ts
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Type declarations for the ms-python.vscode-python-envs extension API.
+ * Subset of types from https://github.com/microsoft/vscode-python-environments/blob/main/src/api.ts
+ * covering only the API surface used by this extension.
+ */
+
+import { Event, Uri } from 'vscode';
+
+/**
+ * Options for executing a Python executable.
+ */
+export interface PythonCommandRunConfiguration {
+    /**
+     * Path to the binary like `python.exe` or `python3` to execute.
+     */
+    executable: string;
+
+    /**
+     * Arguments to pass to the python executable.
+     */
+    args?: string[];
+}
+
+/**
+ * Contains details on how to use a particular python environment.
+ */
+export interface PythonEnvironmentExecutionInfo {
+    /**
+     * Details on how to run the python executable.
+     */
+    run: PythonCommandRunConfiguration;
+
+    /**
+     * Details on how to run the python executable after activating the environment.
+     */
+    activatedRun?: PythonCommandRunConfiguration;
+
+    /**
+     * Details on how to activate an environment.
+     */
+    activation?: PythonCommandRunConfiguration[];
+}
+
+/**
+ * Interface representing information about a Python environment.
+ */
+export interface PythonEnvironmentInfo {
+    /**
+     * The name of the Python environment.
+     */
+    readonly name: string;
+
+    /**
+     * The display name of the Python environment.
+     */
+    readonly displayName: string;
+
+    /**
+     * The version of the Python environment.
+     */
+    readonly version: string;
+
+    /**
+     * Path to the python binary or environment folder.
+     */
+    readonly environmentPath: Uri;
+
+    /**
+     * Information on how to execute the Python environment.
+     */
+    readonly execInfo: PythonEnvironmentExecutionInfo;
+
+    /**
+     * `sys.prefix` path for the Python installation.
+     */
+    readonly sysPrefix: string;
+}
+
+/**
+ * Interface representing the ID of a Python environment.
+ */
+export interface PythonEnvironmentId {
+    /**
+     * The unique identifier of the Python environment.
+     */
+    id: string;
+
+    /**
+     * The ID of the manager responsible for the Python environment.
+     */
+    managerId: string;
+}
+
+/**
+ * Interface representing a Python environment.
+ */
+export interface PythonEnvironment extends PythonEnvironmentInfo {
+    /**
+     * The ID of the Python environment.
+     */
+    readonly envId: PythonEnvironmentId;
+}
+
+/**
+ * Type representing the scope for getting a Python environment.
+ */
+export type GetEnvironmentScope = undefined | Uri;
+
+/**
+ * Event arguments for when the current Python environment changes.
+ */
+export interface DidChangeEnvironmentEventArgs {
+    readonly uri: Uri | undefined;
+    readonly old: PythonEnvironment | undefined;
+    readonly new: PythonEnvironment | undefined;
+}
+
+/**
+ * The API exported by the ms-python.vscode-python-envs extension.
+ * This is the subset of PythonEnvironmentApi used by this extension.
+ */
+export interface PythonEnvironmentsAPI {
+    /**
+     * Retrieves the current Python environment within the specified scope.
+     */
+    getEnvironment(scope: GetEnvironmentScope): Promise<PythonEnvironment | undefined>;
+
+    /**
+     * Event that is fired when the selected Python environment changes.
+     */
+    onDidChangeEnvironment: Event<DidChangeEnvironmentEventArgs>;
+}


### PR DESCRIPTION
This pull request updates the Python environment detection logic to prefer the newer Python Environments extension over the legacy Python extension, improving reliability and accuracy in identifying Python interpreters. The changes ensure that if the Python Environments extension is available, it is used for environment discovery and event handling; otherwise, the code falls back to the legacy extension.

**Python Environment Detection Improvements:**

* Added `getEnvironmentsExtensionAPI()` to check for and activate the Python Environments extension (`ms-python.vscode-python-envs`), enabling use of its API for environment management.
* Updated `initializePython()` to subscribe to environment change events from the Python Environments extension if available, and only fall back to the legacy extension if not.
* Modified `getInterpreterDetails()` to use the Python Environments extension for interpreter resolution when available, improving accuracy of interpreter path detection.

Fixes #403 