### PR TITLE
Add Python Environments extension support with legacy fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@vscode/python-extension": "^1.0.6",
                 "fs-extra": "^11.3.3",
+                "semver": "^7.7.4",
                 "vscode-languageclient": "^8.1.0"
             },
             "devDependencies": {
@@ -19,6 +20,7 @@
                 "@types/glob": "^9.0.0",
                 "@types/mocha": "^10.0.10",
                 "@types/node": "22.x",
+                "@types/semver": "^7.7.1",
                 "@types/sinon": "^21.0.0",
                 "@types/vscode": "^1.74.0",
                 "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -909,6 +911,13 @@
             "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
             "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
             "dev": true
+        },
+        "node_modules/@types/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/sinon": {
             "version": "21.0.0",
@@ -6127,9 +6136,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -8252,6 +8261,12 @@
             "version": "2.1.7",
             "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
             "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+            "dev": true
+        },
+        "@types/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
             "dev": true
         },
         "@types/sinon": {
@@ -11908,9 +11923,9 @@
             }
         },
         "semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
         },
         "serialize-javascript": {
             "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "dependencies": {
         "@vscode/python-extension": "^1.0.6",
         "fs-extra": "^11.3.3",
+        "semver": "^7.7.4",
         "vscode-languageclient": "^8.1.0"
     },
     "devDependencies": {
@@ -218,6 +219,7 @@
         "@types/glob": "^9.0.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
+        "@types/semver": "^7.7.1",
         "@types/sinon": "^21.0.0",
         "@types/vscode": "^1.74.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -2,29 +2,46 @@
 // Licensed under the MIT License.
 
 /* eslint-disable @typescript-eslint/naming-convention */
-import { commands, Disposable, extensions, Event, EventEmitter, Uri } from 'vscode';
-import { traceError, traceLog } from './logging';
 import { PythonExtension, ResolvedEnvironment } from '@vscode/python-extension';
-import { PythonEnvironmentsAPI } from '../typings/pythonEnvironments';
+import * as semver from 'semver';
+import { commands, Disposable, Event, EventEmitter, extensions, Uri } from 'vscode';
 import { PYTHON_MAJOR, PYTHON_MINOR, PYTHON_VERSION } from './constants';
+import { traceError, traceLog } from './logging';
 import { getProjectRoot } from './utilities';
-
-const PYTHON_ENVIRONMENTS_EXTENSION_ID = 'ms-python.vscode-python-envs';
-
-async function getEnvironmentsExtensionAPI(): Promise<PythonEnvironmentsAPI | undefined> {
-    const extension = extensions.getExtension(PYTHON_ENVIRONMENTS_EXTENSION_ID);
-    if (!extension) {
-        return undefined;
-    }
-    if (!extension.isActive) {
-        await extension.activate();
-    }
-    return extension.exports as PythonEnvironmentsAPI;
-}
+import type { PythonEnvironment, PythonEnvironmentsAPI } from '../typings/pythonEnvironments';
 
 export interface IInterpreterDetails {
     path?: string[];
     resource?: Uri;
+}
+
+function convertToResolvedEnvironment(environment: PythonEnvironment): ResolvedEnvironment | undefined {
+    const runConfig = environment.execInfo?.activatedRun ?? environment.execInfo?.run;
+    const executable = runConfig?.executable;
+    if (!executable) {
+        return undefined;
+    }
+    const coerced = semver.coerce(environment.version);
+    return {
+        id: environment.envId?.id ?? '',
+        path: executable,
+        executable: {
+            uri: Uri.file(executable),
+            bitness: 'Unknown',
+            sysPrefix: environment.sysPrefix ?? '',
+        },
+        version: coerced
+            ? {
+                  major: coerced.major,
+                  minor: coerced.minor,
+                  micro: coerced.patch,
+                  release: { level: 'final', serial: 0 },
+                  sysVersion: environment.version ?? '',
+              }
+            : undefined,
+        environment: undefined,
+        tools: [],
+    } as ResolvedEnvironment;
 }
 
 const onDidChangePythonInterpreterEvent = new EventEmitter<void>();
@@ -37,6 +54,34 @@ async function getPythonExtensionAPI(): Promise<PythonExtension | undefined> {
     }
     _api = await PythonExtension.api();
     return _api;
+}
+
+const PYTHON_ENVIRONMENTS_EXTENSION_ID = 'ms-python.vscode-python-envs';
+
+let _envsApi: PythonEnvironmentsAPI | undefined;
+async function getEnvironmentsExtensionAPI(): Promise<PythonEnvironmentsAPI | undefined> {
+    if (_envsApi) {
+        return _envsApi;
+    }
+    const extension = extensions.getExtension(PYTHON_ENVIRONMENTS_EXTENSION_ID);
+    if (!extension) {
+        return undefined;
+    }
+    try {
+        if (!extension.isActive) {
+            await extension.activate();
+        }
+        const api = extension.exports;
+        if (!api) {
+            traceError('Python environments extension did not provide any exports.');
+            return undefined;
+        }
+        _envsApi = api as PythonEnvironmentsAPI;
+        return _envsApi;
+    } catch (ex) {
+        traceError('Failed to activate or retrieve API from Python environments extension.', ex as Error);
+        return undefined;
+    }
 }
 
 function sameInterpreter(a: string[], b: string[]): boolean {
@@ -80,25 +125,29 @@ export async function initializePython(disposables: Disposable[]): Promise<void>
     try {
         // Prefer the Python Environments extension if it's available, as it provides a more comprehensive view of the available environments.
         const envsApi = await getEnvironmentsExtensionAPI();
+
         if (envsApi) {
             disposables.push(
                 envsApi.onDidChangeEnvironment(async () => {
                     await refreshServerPython();
                 }),
             );
-            traceLog('Waiting for interpreter from Python Environments extension.');
+
+            traceLog('Waiting for interpreter from Python environments extension.');
             await refreshServerPython();
             return;
         }
 
         // Fall back to legacy ms-python.python extension API
         const api = await getPythonExtensionAPI();
+
         if (api) {
             disposables.push(
                 api.environments.onDidChangeActiveEnvironmentPath(async () => {
                     await refreshServerPython();
                 }),
             );
+
             traceLog('Waiting for interpreter from Python extension.');
             await refreshServerPython();
         }
@@ -107,7 +156,16 @@ export async function initializePython(disposables: Disposable[]): Promise<void>
     }
 }
 
+// TODO: Unused code
 export async function resolveInterpreter(interpreter: string[]): Promise<ResolvedEnvironment | undefined> {
+    const envsApi = await getEnvironmentsExtensionAPI();
+    if (envsApi) {
+        const environment = await envsApi.resolveEnvironment(Uri.file(interpreter[0]));
+        if (!environment) {
+            return undefined;
+        }
+        return convertToResolvedEnvironment(environment);
+    }
     const api = await getPythonExtensionAPI();
     return api?.environments.resolveEnvironment(interpreter[0]);
 }
@@ -116,14 +174,32 @@ export async function getInterpreterDetails(resource?: Uri): Promise<IInterprete
     // Prefer the Python Environments extension if it's available, as it provides a more comprehensive view of the available environments.
     const envsApi = await getEnvironmentsExtensionAPI();
     if (envsApi) {
-        const environment = await envsApi.getEnvironment(resource);
-        if (environment) {
-            const executablePath = environment.execInfo?.run?.executable ?? environment.environmentPath.fsPath;
-            traceLog(`Using Python interpreter from Python Environments extension: ${executablePath}`);
-            return { path: [executablePath], resource };
+        try {
+            const environment = await envsApi.getEnvironment(resource);
+            if (environment) {
+                const coerced = semver.coerce(environment.version);
+                const runConfig = environment.execInfo?.activatedRun ?? environment.execInfo?.run;
+                const executable = runConfig?.executable;
+                const args = runConfig?.args ?? [];
+                if (coerced && coerced.major === PYTHON_MAJOR && coerced.minor >= PYTHON_MINOR) {
+                    if (executable) {
+                        return { path: [executable, ...args], resource };
+                    }
+                    traceError('No executable found for selected Python environment.');
+                    return { path: undefined, resource };
+                }
+                traceError(`Python version ${environment.version} is not supported.`);
+                traceError(`Selected python path: ${runConfig?.executable}`);
+                traceError(`Supported versions are ${PYTHON_VERSION} and above.`);
+                return { path: undefined, resource };
+            }
+            // No environment found via envs API, fall through to legacy resolver.
+        } catch (error) {
+            traceError('Error getting interpreter from Python environments extension: ', error);
+            // Fall through to legacy resolver.
         }
-        return { path: undefined, resource };
     }
+
     // Fall back to legacy ms-python.python extension API
     const api = await getPythonExtensionAPI();
     const environment = await api?.environments.resolveEnvironment(
@@ -135,13 +211,18 @@ export async function getInterpreterDetails(resource?: Uri): Promise<IInterprete
     return { path: undefined, resource };
 }
 
+// TODO: The Python Environments extension does not expose a debug API yet; uses legacy ms-python.python
 export async function getDebuggerPath(): Promise<string | undefined> {
     const api = await getPythonExtensionAPI();
     return api?.debug.getDebuggerPackagePath();
 }
 
+// TODO: Unused code
 export async function runPythonExtensionCommand(command: string, ...rest: any[]) {
-    await getPythonExtensionAPI();
+    const envsApi = await getEnvironmentsExtensionAPI();
+    if (!envsApi) {
+        await getPythonExtensionAPI();
+    }
     return await commands.executeCommand(command, ...rest);
 }
 
@@ -151,7 +232,7 @@ export function checkVersion(resolved: ResolvedEnvironment | undefined): boolean
         return true;
     }
     traceError(`Python version ${version?.major}.${version?.minor} is not supported.`);
-    traceError(`Selected Python path: ${resolved?.executable.uri?.fsPath}`);
+    traceError(`Selected python path: ${resolved?.executable.uri?.fsPath}`);
     traceError(`Supported versions are ${PYTHON_VERSION} and above.`);
     return false;
 }

--- a/src/typings/pythonEnvironments.d.ts
+++ b/src/typings/pythonEnvironments.d.ts
@@ -119,6 +119,11 @@ export interface DidChangeEnvironmentEventArgs {
 }
 
 /**
+ * Type representing the context for resolving a Python environment.
+ */
+export type ResolveEnvironmentContext = Uri;
+
+/**
  * The API exported by the ms-python.vscode-python-envs extension.
  * This is the subset of PythonEnvironmentApi used by this extension.
  */
@@ -127,6 +132,11 @@ export interface PythonEnvironmentsAPI {
      * Retrieves the current Python environment within the specified scope.
      */
     getEnvironment(scope: GetEnvironmentScope): Promise<PythonEnvironment | undefined>;
+
+    /**
+     * Resolves a Python environment from a Uri context.
+     */
+    resolveEnvironment(context: ResolveEnvironmentContext): Promise<PythonEnvironment | undefined>;
 
     /**
      * Event that is fired when the selected Python environment changes.


### PR DESCRIPTION
## Summary
Adds support for the new \ms-python.vscode-python-envs\ extension as the preferred interpreter resolver, with graceful fallback to the legacy \ms-python.python\ extension.

Aligned with identical changes across [vscode-isort#555](https://github.com/microsoft/vscode-isort/pull/555), [vscode-mypy#449](https://github.com/microsoft/vscode-mypy/pull/449), [vscode-pylint#716](https://github.com/microsoft/vscode-pylint/pull/716), and [vscode-black-formatter#643](https://github.com/microsoft/vscode-black-formatter/pull/643).

## Changes

### \src/common/python.ts\
- **\getEnvironmentsExtensionAPI()\**: Added try/catch, null-exports check, and result caching
- **\getInterpreterDetails()\**: Prefers envs API with version validation via \semver.coerce()\, uses \ctivatedRun\ with \rgs\ for conda/pyenv support, falls through to legacy when envs API returns no environment or throws
- **\esolveInterpreter()\**: Now supports envs API via \convertToResolvedEnvironment()\ type conversion
- **\unPythonExtensionCommand()\**: Checks envs extension activation first
- **\import type\** for \PythonEnvironment\/\PythonEnvironmentsAPI\
- TODO comments for \getDebuggerPath\ (no debug API in envs extension yet) and unused exports

### \src/typings/pythonEnvironments.d.ts\
- Added \esolveEnvironment()\ method and \ResolveEnvironmentContext\ type

### Dependencies
- Added \semver\ (direct) and \@types/semver\ (dev) for robust Python version parsing
