### PR TITLE
Refactor: add exit_code field to RunResult

### DIFF
--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import sysconfig
 import threading
-from typing import Any, Callable, List, Sequence, Tuple, Union
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
 # Save the working directory used when loading this module
 SERVER_CWD = os.getcwd()
@@ -131,9 +131,12 @@ def is_match(patterns: List[str], file_path: str) -> bool:
 class RunResult:
     """Object to hold result from running tool."""
 
-    def __init__(self, stdout: str, stderr: str):
+    def __init__(
+        self, stdout: str, stderr: str, exit_code: Optional[Union[int, str]] = None
+    ):
         self.stdout: str = stdout
         self.stderr: str = stderr
+        self.exit_code: Optional[Union[int, str]] = exit_code
 
 
 class CustomIO(io.TextIOWrapper):


### PR DESCRIPTION
## Summary

Add an \xit_code\ field to the \RunResult\ class in \undled/tool/lsp_utils.py\, matching mypy's implementation pattern.

## Changes

- Added \xit_code: Optional[Union[int, str]] = None\ parameter to \RunResult.__init__\
- Added \Optional\ to the \	yping\ imports
- Default is \None\, so **all existing callers continue to work unchanged**

## References

- Part of #465
- Ref: microsoft/vscode-python-tools-extension-template#290