### PR TITLE
Refactor: backport shared test coverage (envFile + utilities + configWatcher dispose)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
                 "@vscode/python-extension": "^1.0.6",
-                "dotenv": "^17.4.0",
+                "dotenv": "^17.4.1",
                 "fs-extra": "^11.3.4",
                 "semver": "^7.7.4",
                 "vscode-languageclient": "^8.1.0"
@@ -2709,9 +2709,9 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "17.4.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
-            "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
+            "version": "17.4.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+            "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
@@ -9502,9 +9502,9 @@
             }
         },
         "dotenv": {
-            "version": "17.4.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
-            "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ=="
+            "version": "17.4.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+            "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="
         },
         "dunder-proto": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "dependencies": {
         "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
         "@vscode/python-extension": "^1.0.6",
-        "dotenv": "^17.4.0",
+        "dotenv": "^17.4.1",
         "fs-extra": "^11.3.4",
         "semver": "^7.7.4",
         "vscode-languageclient": "^8.1.0"

--- a/src/test/ts_tests/tests/common/configWatcher.unit.test.ts
+++ b/src/test/ts_tests/tests/common/configWatcher.unit.test.ts
@@ -9,6 +9,9 @@ import { FLAKE8_CONFIG_FILES } from '../../../../common/constants';
 
 interface MockFileSystemWatcher {
     watcher: FileSystemWatcher;
+    changeDisposable: { dispose: sinon.SinonStub };
+    createDisposable: { dispose: sinon.SinonStub };
+    deleteDisposable: { dispose: sinon.SinonStub };
     fireDidCreate(): Promise<void>;
     fireDidChange(): Promise<void>;
     fireDidDelete(): Promise<void>;
@@ -19,26 +22,33 @@ function createMockFileSystemWatcher(): MockFileSystemWatcher {
     let onDidCreateHandler: ((e: Uri) => Promise<void>) | undefined;
     let onDidDeleteHandler: ((e: Uri) => Promise<void>) | undefined;
 
+    const changeDisposable = { dispose: sinon.stub() };
+    const createDisposable = { dispose: sinon.stub() };
+    const deleteDisposable = { dispose: sinon.stub() };
+
     const watcher = {
-        onDidChange: (handler: (e: Uri) => Promise<void>): Disposable => {
+        onDidChange: sinon.stub().callsFake((handler: (e: Uri) => Promise<void>): Disposable => {
             onDidChangeHandler = handler;
-            return { dispose: () => {} };
-        },
-        onDidCreate: (handler: (e: Uri) => Promise<void>): Disposable => {
+            return changeDisposable;
+        }),
+        onDidCreate: sinon.stub().callsFake((handler: (e: Uri) => Promise<void>): Disposable => {
             onDidCreateHandler = handler;
-            return { dispose: () => {} };
-        },
-        onDidDelete: (handler: (e: Uri) => Promise<void>): Disposable => {
+            return createDisposable;
+        }),
+        onDidDelete: sinon.stub().callsFake((handler: (e: Uri) => Promise<void>): Disposable => {
             onDidDeleteHandler = handler;
-            return { dispose: () => {} };
-        },
-        dispose: () => {},
+            return deleteDisposable;
+        }),
+        dispose: sinon.stub(),
     } as unknown as FileSystemWatcher;
 
     const fakeUri = Uri.file('/fake/config/file');
 
     return {
         watcher,
+        changeDisposable,
+        createDisposable,
+        deleteDisposable,
         fireDidCreate: async () => {
             if (onDidCreateHandler) {
                 await onDidCreateHandler(fakeUri);
@@ -61,9 +71,11 @@ suite('Config File Watcher Tests', () => {
     let sandbox: sinon.SinonSandbox;
     let createFileSystemWatcherStub: sinon.SinonStub;
     let mockWatchers: MockFileSystemWatcher[];
+    let onConfigChangedCallback: sinon.SinonStub;
 
     setup(() => {
         sandbox = sinon.createSandbox();
+        onConfigChangedCallback = sandbox.stub().resolves();
         mockWatchers = FLAKE8_CONFIG_FILES.map(() => createMockFileSystemWatcher());
 
         let watcherIndex = 0;
@@ -140,5 +152,30 @@ suite('Config File Watcher Tests', () => {
         for (const d of disposables) {
             assert.isFunction(d.dispose);
         }
+    });
+
+    test('Should dispose all subscriptions and watcher on dispose', () => {
+        const watchers = createConfigFileWatchers(onConfigChangedCallback);
+
+        watchers[0].dispose();
+
+        const { changeDisposable, createDisposable, deleteDisposable, watcher: mockWatcher } = mockWatchers[0];
+        assert.strictEqual(changeDisposable.dispose.callCount, 1, 'Change subscription should be disposed');
+        assert.strictEqual(createDisposable.dispose.callCount, 1, 'Create subscription should be disposed');
+        assert.strictEqual(deleteDisposable.dispose.callCount, 1, 'Delete subscription should be disposed');
+        assert.strictEqual((mockWatcher.dispose as sinon.SinonStub).callCount, 1, 'Watcher should be disposed');
+    });
+
+    test('Should not call callback after dispose', () => {
+        const watchers = createConfigFileWatchers(onConfigChangedCallback);
+
+        // Dispose the watcher
+        watchers[0].dispose();
+
+        // Get the handlers and call them after disposal
+        const changeHandler = (mockWatchers[0].watcher.onDidChange as sinon.SinonStub).getCall(0).args[0];
+        changeHandler();
+
+        assert.strictEqual(onConfigChangedCallback.callCount, 0, 'Callback should not be called after dispose');
     });
 });

--- a/src/test/ts_tests/tests/common/envFile.unit.test.ts
+++ b/src/test/ts_tests/tests/common/envFile.unit.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { assert } from 'chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { Uri, WorkspaceFolder } from 'vscode';
+import { getEnvFileVars } from '../../../../common/envFile';
+import * as vscodeapi from '../../../../common/vscodeapi';
+
+// Use real files instead of stubbing fs-extra (whose exports are non-configurable).
+suite('getEnvFileVars Tests', () => {
+    let getConfigurationStub: sinon.SinonStub;
+
+    const fixtureDir = path.join(__dirname, '.envfile-test-fixtures');
+
+    const workspaceFolder: WorkspaceFolder = {
+        uri: Uri.file(fixtureDir),
+        name: 'workspace',
+        index: 0,
+    };
+
+    setup(async () => {
+        await fs.ensureDir(fixtureDir);
+        getConfigurationStub = sinon.stub(vscodeapi, 'getConfiguration');
+    });
+
+    teardown(async () => {
+        sinon.restore();
+        await fs.remove(fixtureDir);
+    });
+
+    test('returns parsed variables from existing .env file', async () => {
+        await fs.writeFile(path.join(fixtureDir, '.env'), 'FOO=bar\nBAZ=qux\n');
+        getConfigurationStub.returns({
+            get: (_key: string, defaultValue: string) => defaultValue,
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        assert.deepStrictEqual(vars, { FOO: 'bar', BAZ: 'qux' });
+    });
+
+    test('returns empty object for missing file', async () => {
+        getConfigurationStub.returns({
+            get: (_key: string, defaultValue: string) => defaultValue,
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        assert.deepStrictEqual(vars, {});
+    });
+
+    test('resolves ${workspaceFolder} in path', async () => {
+        await fs.writeFile(path.join(fixtureDir, '.env.test'), 'KEY=value\n');
+        getConfigurationStub.returns({
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            get: (_key: string, _defaultValue: string) => '${workspaceFolder}/.env.test',
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        assert.deepStrictEqual(vars, { KEY: 'value' });
+    });
+
+    test('resolves relative paths', async () => {
+        await fs.writeFile(path.join(fixtureDir, '.env.local'), 'RELATIVE=yes\n');
+        getConfigurationStub.returns({
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            get: (_key: string, _defaultValue: string) => '.env.local',
+        });
+
+        const vars = await getEnvFileVars(workspaceFolder);
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        assert.deepStrictEqual(vars, { RELATIVE: 'yes' });
+    });
+});

--- a/src/test/ts_tests/tests/common/utilities.unit.test.ts
+++ b/src/test/ts_tests/tests/common/utilities.unit.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+import * as vscodeapi from '../../../../common/vscodeapi';
+import { getDocumentSelector, getInterpreterFromSetting } from '../../../../common/utilities';
+
+suite('Document Selector Tests', () => {
+    let isVirtualWorkspaceStub: sinon.SinonStub;
+    setup(() => {
+        isVirtualWorkspaceStub = sinon.stub(vscodeapi, 'isVirtualWorkspace');
+        isVirtualWorkspaceStub.returns(false);
+    });
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Document selector default', () => {
+        const selector = getDocumentSelector();
+        assert.deepStrictEqual(selector, [
+            { scheme: 'file', language: 'python' },
+            { scheme: 'untitled', language: 'python' },
+            { scheme: 'vscode-notebook', language: 'python' },
+            { scheme: 'vscode-notebook-cell', language: 'python' },
+        ]);
+    });
+    test('Document selector virtual workspace', () => {
+        isVirtualWorkspaceStub.returns(true);
+        const selector = getDocumentSelector();
+        assert.deepStrictEqual(selector, [{ language: 'python' }]);
+    });
+});
+
+suite('getInterpreterFromSetting Tests', () => {
+    let getConfigurationStub: sinon.SinonStub;
+
+    setup(() => {
+        getConfigurationStub = sinon.stub(vscodeapi, 'getConfiguration');
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Returns interpreter array from configuration', () => {
+        const expectedInterpreter = ['/usr/bin/python3'];
+        getConfigurationStub.returns({
+            get: (key: string) => {
+                if (key === 'interpreter') {
+                    return expectedInterpreter;
+                }
+                return undefined;
+            },
+        });
+
+        const result = getInterpreterFromSetting('flake8');
+        assert.deepStrictEqual(result, expectedInterpreter);
+        assert.isTrue(getConfigurationStub.calledOnceWith('flake8'));
+    });
+
+    test('Returns undefined when interpreter is not set', () => {
+        getConfigurationStub.returns({
+            get: () => undefined,
+        });
+
+        const result = getInterpreterFromSetting('flake8');
+        assert.isUndefined(result);
+    });
+});


### PR DESCRIPTION
Backports shared test coverage from sibling extension repos to ensure consistent test coverage before shared package extraction.

### Changes
- **envFile.unit.test.ts** (4 tests): Tests for `getEnvFileVars` — env file parsing, missing file handling, variable resolution. Copied from isort.
- **utilities.unit.test.ts** (4 tests): Tests for `getDocumentSelector` and `getInterpreterFromSetting`. Copied from black-formatter.
- **configWatcher dispose** (2 tests): Tests that disposal properly cleans up subscriptions and prevents post-dispose callbacks. Backported from pylint.

Part of microsoft/vscode-python-tools-extension-template#290