### PR TITLE
refactor: normalize lsp_utils.py signatures

### DIFF
--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -88,7 +88,7 @@ def normalize_path(file_path: str, resolve_symlinks: bool = True) -> str:
     return str(path)
 
 
-def is_current_interpreter(executable) -> bool:
+def is_current_interpreter(executable: str) -> bool:
     """Returns true if the executable path is same as the current interpreter."""
     return is_same_path(executable, sys.executable)
 
@@ -230,8 +230,9 @@ def _run_module(
     """Runs as a module."""
     str_output = CustomIO("<stdout>", encoding="utf-8")
     str_error = CustomIO("<stderr>", encoding="utf-8")
+    exit_code = None
 
-    with contextlib.suppress(SystemExit):
+    try:
         with substitute_attr(sys, "argv", argv):
             with redirect_io("stdout", str_output):
                 with redirect_io("stderr", str_error):
@@ -243,8 +244,10 @@ def _run_module(
                             runpy.run_module(module, run_name="__main__")
                     else:
                         runpy.run_module(module, run_name="__main__")
+    except SystemExit as ex:
+        exit_code = ex.code
 
-    return RunResult(str_output.get_value(), str_error.get_value())
+    return RunResult(str_output.get_value(), str_error.get_value(), exit_code)
 
 
 def run_module(


### PR DESCRIPTION
Aligns Python module signatures across repos for shared package extraction:

- **RunResult**: Add `exit_code: Optional[Union[int, str]] = None` parameter and capture `SystemExit.code` in `_run_module` (matches mypy pattern)
- **is_current_interpreter**: Add `executable: str` type annotation (matches isort/mypy/pylint)

All changes backward-compatible — no behavioral changes to existing callers.