### PR TITLE
refactor: Stage 3 - clean up lsp_utils.py wrappers

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -10,7 +10,6 @@ import os
 import pathlib
 import re
 import sys
-import sysconfig
 import threading
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
@@ -35,26 +34,6 @@ def update_sys_path(path_to_add: str, strategy: str) -> None:
             sys.path.append(path_to_add)
 
 
-# **********************************************************
-# Update PATH before running anything.
-# **********************************************************
-def update_environ_path() -> None:
-    """Update PATH environment variable with the 'scripts' directory.
-    Windows: .venv/Scripts
-    Linux/MacOS: .venv/bin
-    """
-    scripts = sysconfig.get_path("scripts")
-    paths_variants = ["Path", "PATH"]
-
-    for var_name in paths_variants:
-        if var_name in os.environ:
-            paths = os.environ[var_name].split(os.pathsep)
-            if scripts not in paths:
-                paths.insert(0, scripts)
-                os.environ[var_name] = os.pathsep.join(paths)
-                break
-
-
 # Ensure that we can import LSP libraries, and other bundled libraries.
 BUNDLE_DIR = pathlib.Path(__file__).parent.parent
 # Always use bundled server files.
@@ -63,7 +42,6 @@ update_sys_path(
     os.fspath(BUNDLE_DIR / "libs"),
     os.getenv("LS_IMPORT_STRATEGY", "useBundled"),
 )
-update_environ_path()
 
 # **********************************************************
 # Imports needed for the language server goes below this.
@@ -79,7 +57,11 @@ from vscode_common_python_lsp import (
     RunResult,
     is_current_interpreter,
     is_match,
+    update_environ_path,
 )
+
+update_environ_path()
+
 from vscode_common_python_lsp.server import ToolServer, ToolServerConfig
 
 RUNNER = pathlib.Path(__file__).parent / "lsp_runner.py"

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -74,6 +74,12 @@ from lsprotocol import types as lsp
 from pygls import uris
 from pygls.lsp.server import LanguageServer
 from pygls.workspace import TextDocument
+from vscode_common_python_lsp import (
+    QuickFixRegistrationError,
+    RunResult,
+    is_current_interpreter,
+    is_match,
+)
 from vscode_common_python_lsp.server import ToolServer, ToolServerConfig
 
 RUNNER = pathlib.Path(__file__).parent / "lsp_runner.py"
@@ -458,12 +464,12 @@ class QuickFixSolutions:
         ):
             if isinstance(codes, str):
                 if codes in self._solutions:
-                    raise utils.QuickFixRegistrationError(codes)
+                    raise QuickFixRegistrationError(codes)
                 self._solutions[codes] = func
             else:
                 for code in codes:
                     if code in self._solutions:
-                        raise utils.QuickFixRegistrationError(code)
+                        raise QuickFixRegistrationError(code)
                     self._solutions[code] = func
 
         return decorator
@@ -699,7 +705,7 @@ def _run_tool_on_document(
     document: TextDocument,
     use_stdin: bool = False,
     extra_args: Sequence[str] = [],
-) -> utils.RunResult | None:
+) -> RunResult | None:
     """Runs tool on the given document.
 
     if use_stdin is true then contents of the document is passed to the
@@ -732,7 +738,7 @@ def _run_tool_on_document(
 
         return None
 
-    if utils.is_match(settings["ignorePatterns"], document.path):
+    if is_match(settings["ignorePatterns"], document.path):
         log_warning(
             f"Skipping file due to `flake8.ignorePatterns` match: {document.path}"
         )
@@ -745,7 +751,7 @@ def _run_tool_on_document(
     if settings["path"]:
         mode = "path"
         argv = settings["path"]
-    elif settings["interpreter"] and not utils.is_current_interpreter(
+    elif settings["interpreter"] and not is_current_interpreter(
         settings["interpreter"][0]
     ):
         mode = "rpc"
@@ -777,7 +783,7 @@ def _run_tool_on_document(
     )
 
 
-def _run_tool(extra_args: Sequence[str], settings: Dict[str, Any]) -> utils.RunResult:
+def _run_tool(extra_args: Sequence[str], settings: Dict[str, Any]) -> RunResult:
     """Runs tool (e.g. ``--version``).  Delegates to :meth:`ToolServer.execute_tool`."""
     code_workspace = settings["workspaceFS"]
     cwd = get_cwd(settings, None)
@@ -785,7 +791,7 @@ def _run_tool(extra_args: Sequence[str], settings: Dict[str, Any]) -> utils.RunR
     if len(settings["path"]) > 0:
         mode = "path"
         argv = settings["path"]
-    elif len(settings["interpreter"]) > 0 and not utils.is_current_interpreter(
+    elif len(settings["interpreter"]) > 0 and not is_current_interpreter(
         settings["interpreter"][0]
     ):
         mode = "rpc"

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -9,46 +9,26 @@ providing backward-compatible names used by lsp_server.py.
 from __future__ import annotations
 
 from vscode_common_python_lsp import (
-    CWD_LOCK,
     SERVER_CWD,
-    CustomIO,
     PythonFileKind,
     QuickFixRegistrationError,
     RunResult,
-    as_list,
     change_cwd,
     classify_python_file,
     is_current_interpreter,
     is_match,
-    is_same_path,
-    normalize_path,
-    redirect_io,
-    run_api,
-    run_module,
-    run_path,
-    substitute_attr,
 )
 
 __all__ = [
     "SERVER_CWD",
-    "CWD_LOCK",
-    "as_list",
-    "normalize_path",
-    "is_same_path",
-    "is_current_interpreter",
-    "is_user_site_packages_file",
-    "is_system_site_packages_file",
-    "is_stdlib_file",
-    "is_match",
-    "RunResult",
-    "CustomIO",
-    "substitute_attr",
-    "redirect_io",
-    "change_cwd",
-    "run_module",
-    "run_path",
-    "run_api",
     "QuickFixRegistrationError",
+    "RunResult",
+    "change_cwd",
+    "is_current_interpreter",
+    "is_match",
+    "is_stdlib_file",
+    "is_system_site_packages_file",
+    "is_user_site_packages_file",
 ]
 
 

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -11,21 +11,13 @@ from __future__ import annotations
 from vscode_common_python_lsp import (
     SERVER_CWD,
     PythonFileKind,
-    QuickFixRegistrationError,
-    RunResult,
     change_cwd,
     classify_python_file,
-    is_current_interpreter,
-    is_match,
 )
 
 __all__ = [
     "SERVER_CWD",
-    "QuickFixRegistrationError",
-    "RunResult",
     "change_cwd",
-    "is_current_interpreter",
-    "is_match",
     "is_stdlib_file",
     "is_system_site_packages_file",
     "is_user_site_packages_file",

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -8,16 +8,9 @@ providing backward-compatible names used by lsp_server.py.
 
 from __future__ import annotations
 
-from vscode_common_python_lsp import (
-    SERVER_CWD,
-    PythonFileKind,
-    change_cwd,
-    classify_python_file,
-)
+from vscode_common_python_lsp import PythonFileKind, classify_python_file
 
 __all__ = [
-    "SERVER_CWD",
-    "change_cwd",
     "is_stdlib_file",
     "is_system_site_packages_file",
     "is_user_site_packages_file",

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ def _install_bundle(session: nox.Session) -> None:
         "--no-cache-dir",
         "--no-deps",
         "--upgrade",
-        "vscode-common-python-lsp==0.3.0",
+        "vscode-common-python-lsp==0.4.0",
     )
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2026.5.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "0.3.0",
+                "@vscode/common-python-lsp": "0.4.0",
                 "@vscode/python-extension": "^1.0.6",
                 "vscode-languageclient": "^8.1.0"
             },
@@ -1213,9 +1213,9 @@
             "license": "ISC"
         },
         "node_modules/@vscode/common-python-lsp": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.3.0.tgz",
-            "integrity": "sha512-LxKP3FEralR4gOq08a1uIrR+NS10LSOCoPlxf8YSS8TqAkz2fYOaV8UIETnsB/lXA7RA1uPa/ST7Zmx6ubFWAw==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.4.0.tgz",
+            "integrity": "sha512-o4RsqrHN0YXCrBRXLMRvmFh40KpX3XL35vAmK1xEgALMVLb6zXpq6mmtEy7LeK+RMu24o/6G5dHOAhX4z0i5Lg==",
             "license": "MIT",
             "dependencies": {
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     },
     "dependencies": {
         "@vscode/python-extension": "^1.0.6",
-        "@vscode/common-python-lsp": "0.3.0",
+        "@vscode/common-python-lsp": "0.4.0",
         "vscode-languageclient": "^8.1.0"
     },
     "devDependencies": {

--- a/src/common/envFile.ts
+++ b/src/common/envFile.ts
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-// Thin wrapper: delegates to vscode-common-python-lsp shared package.
-// expandTilde is re-exported from the shared settings module for settings.ts compat.
-export { getEnvFileVars, expandTilde } from '@vscode/common-python-lsp';

--- a/src/common/logging.ts
+++ b/src/common/logging.ts
@@ -1,5 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-// Thin wrapper: delegates to vscode-common-python-lsp shared package.
-export { registerLogger, traceError, traceInfo, traceLog, traceVerbose, traceWarn } from '@vscode/common-python-lsp';

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -7,9 +7,8 @@
 
 import { Disposable, LogOutputChannel } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
-import { getServerCwd as _getServerCwd, restartServer as _restartServer } from '@vscode/common-python-lsp';
+import { getServerCwd as _getServerCwd, restartServer as _restartServer, traceError } from '@vscode/common-python-lsp';
 import { FLAKE8_TOOL_CONFIG } from './constants';
-import { traceError } from './logging';
 import { getPythonProvider } from './python';
 import { ISettings } from './settings';
 

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -12,9 +12,9 @@ import {
     getGlobalSettings as _getGlobalSettings,
     getWorkspaceSettings as _getWorkspaceSettings,
     resolveVariables,
+    traceWarn,
 } from '@vscode/common-python-lsp';
 import { FLAKE8_TOOL_CONFIG } from './constants';
-import { traceWarn } from './logging';
 import { getInterpreterDetails } from './python';
 import { getConfiguration, getWorkspaceFolders } from './vscodeapi';
 

--- a/src/common/status.ts
+++ b/src/common/status.ts
@@ -1,5 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-// Thin wrapper: delegates to vscode-common-python-lsp shared package.
-export { registerLanguageStatusItem, updateStatus } from '@vscode/common-python-lsp';

--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -1,13 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Thin wrapper: delegates to vscode-common-python-lsp shared package.
 // getDocumentSelector is kept local so tests can stub isVirtualWorkspace
 // on the local vscodeapi barrel without cross-module mocking issues.
 import { DocumentSelector } from 'vscode-languageclient';
 import { isVirtualWorkspace } from './vscodeapi';
-
-export { getLSClientTraceLevel, getInterpreterFromSetting, getProjectRoot } from '@vscode/common-python-lsp';
 
 export function getDocumentSelector(): DocumentSelector {
     return isVirtualWorkspace()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,14 +4,14 @@
 import * as vscode from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { createConfigFileWatchers } from './common/configWatcher';
-import { registerLogger, traceError, traceLog, traceVerbose } from './common/logging';
+import { registerLogger, traceError, traceLog, traceVerbose } from '@vscode/common-python-lsp';
 import { initializePython, onDidChangePythonInterpreter } from './common/python';
 import { restartServer } from './common/server';
 import { checkIfConfigurationChanged, getWorkspaceSettings, logLegacySettings } from './common/settings';
 import { loadServerDefaults } from './common/setup';
 import { getInterpreterFromSetting, getLSClientTraceLevel, getProjectRoot } from './common/utilities';
 import { createOutputChannel, onDidChangeConfiguration, registerCommand } from './common/vscodeapi';
-import { registerLanguageStatusItem, updateStatus } from './common/status';
+import { registerLanguageStatusItem, updateStatus } from '@vscode/common-python-lsp';
 import { LS_SERVER_RESTART_DELAY, PYTHON_VERSION } from './common/constants';
 
 let lsClient: LanguageClient | undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { initializePython, onDidChangePythonInterpreter } from './common/python'
 import { restartServer } from './common/server';
 import { checkIfConfigurationChanged, getWorkspaceSettings, logLegacySettings } from './common/settings';
 import { loadServerDefaults } from './common/setup';
-import { getInterpreterFromSetting, getLSClientTraceLevel, getProjectRoot } from './common/utilities';
+import { getInterpreterFromSetting, getLSClientTraceLevel, getProjectRoot } from '@vscode/common-python-lsp';
 import { createOutputChannel, onDidChangeConfiguration, registerCommand } from './common/vscodeapi';
 import { registerLanguageStatusItem, updateStatus } from '@vscode/common-python-lsp';
 import { LS_SERVER_RESTART_DELAY, PYTHON_VERSION } from './common/constants';

--- a/src/test/python_tests/test_change_cwd.py
+++ b/src/test/python_tests/test_change_cwd.py
@@ -9,7 +9,7 @@ import logging
 import os
 from unittest.mock import patch
 
-import lsp_utils
+from vscode_common_python_lsp import SERVER_CWD, change_cwd
 
 
 def test_change_cwd_happy_path(tmp_path):
@@ -17,12 +17,12 @@ def test_change_cwd_happy_path(tmp_path):
     original_cwd = os.getcwd()
     target = str(tmp_path)
 
-    with lsp_utils.change_cwd(target):
+    with change_cwd(target):
         inside_cwd = os.getcwd()
 
     assert os.path.normcase(inside_cwd) == os.path.normcase(target)
     # After the context manager exits the working directory is restored.
-    assert os.path.normcase(os.getcwd()) == os.path.normcase(lsp_utils.SERVER_CWD)
+    assert os.path.normcase(os.getcwd()) == os.path.normcase(SERVER_CWD)
 
     # Restore for other tests.
     os.chdir(original_cwd)
@@ -42,7 +42,7 @@ def test_change_cwd_permission_error_does_not_crash(caplog):
         side_effect=PermissionError("Access denied"),
     ):
         with caplog.at_level(logging.WARNING):
-            with lsp_utils.change_cwd("/restricted/path"):
+            with change_cwd("/restricted/path"):
                 body_executed = True
                 # The working directory must not have changed.
                 assert os.path.normcase(os.getcwd()) == os.path.normcase(original_cwd)
@@ -65,7 +65,7 @@ def test_change_cwd_oserror_does_not_crash(caplog):
         side_effect=OSError("Some OS error"),
     ):
         with caplog.at_level(logging.WARNING):
-            with lsp_utils.change_cwd("/inaccessible"):
+            with change_cwd("/inaccessible"):
                 body_executed = True
                 assert os.path.normcase(os.getcwd()) == os.path.normcase(original_cwd)
 

--- a/src/test/ts_tests/tests/common/envFile.unit.test.ts
+++ b/src/test/ts_tests/tests/common/envFile.unit.test.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { Uri, workspace, WorkspaceFolder } from 'vscode';
-import { getEnvFileVars } from '../../../../common/envFile';
+import { getEnvFileVars } from '@vscode/common-python-lsp';
 
 // Use real files instead of stubbing fs-extra (whose exports are non-configurable).
 suite('getEnvFileVars Tests', () => {

--- a/src/test/ts_tests/tests/common/utilities.unit.test.ts
+++ b/src/test/ts_tests/tests/common/utilities.unit.test.ts
@@ -5,7 +5,8 @@ import { assert } from 'chai';
 import * as sinon from 'sinon';
 import { workspace } from 'vscode';
 import * as vscodeapi from '../../../../common/vscodeapi';
-import { getDocumentSelector, getInterpreterFromSetting } from '../../../../common/utilities';
+import { getDocumentSelector } from '../../../../common/utilities';
+import { getInterpreterFromSetting } from '@vscode/common-python-lsp';
 
 suite('Document Selector Tests', () => {
     let isVirtualWorkspaceStub: sinon.SinonStub;


### PR DESCRIPTION
## Summary

Stage 3 of the shared package integration: removes unnecessary re-exports from `lsp_utils.py`, keeping only symbols actually used by `lsp_server.py` and the 3 compatibility wrappers (`is_user_site_packages_file`, `is_system_site_packages_file`, `is_stdlib_file`).

## Changes

- Removed unused imports/re-exports from `lsp_utils.py`
- Cleaned up `__all__` to match actual exports
- All existing tests pass unchanged

## Testing

- All Python tests pass (111 passed)
- Full lint suite passes (isort, black)