### PR TITLE
Remove shell quotes from flake8 format arg

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -80,7 +80,7 @@ LSP_SERVER = LanguageServer(
 FLAKE8_CONFIG = ToolServerConfig(
     tool_module="flake8",
     tool_display="Flake8",
-    tool_args=["--format='%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s'"],
+    tool_args=["--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s"],
     min_version="5.0.0",
     runner_script=str(RUNNER),
     default_notification_level="onError",

--- a/src/test/python_tests/test_diagnostic_regex.py
+++ b/src/test/python_tests/test_diagnostic_regex.py
@@ -5,7 +5,7 @@ Unit tests for diagnostic regex parsing in lsp_server.
 """
 
 import pytest
-from lsp_server import DIAGNOSTIC_RE
+from lsp_server import DIAGNOSTIC_RE, TOOL_ARGS
 
 
 def _get_group_dict(line: str):
@@ -184,3 +184,8 @@ def test_diagnostic_regex_no_match_without_code():
 def test_diagnostic_regex_no_match_leading_whitespace():
     """Leading whitespace prevents match because .match() is start-anchored."""
     assert _get_group_dict(" 14,5,E,E302:msg") is None
+
+
+def test_flake8_formatter_arg_is_not_shell_quoted():
+    """The built-in formatter must be passed as a raw CLI value, not a quoted shell literal."""
+    assert TOOL_ARGS == ["--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s"]


### PR DESCRIPTION
## Summary
- remove shell-style quotes from the built-in flake8 `--format` argument
- add a regression test to ensure the formatter arg is passed as a raw CLI value

Fixes #503.

## Validation
- `python -m pytest src\test\python_tests\test_diagnostic_regex.py`