### PR TITLE
fix: stop excluding dist-info from packaged extension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -18,7 +18,6 @@ vsc-extension-quickstart.md
 **/__pycache__/**
 **/*.pyc
 bundled/libs/bin/**
-bundled/libs/*.dist-info/**
 noxfile.py
 .pytest_cache/**
 .flake8

--- a/src/test/python_tests/test_packaging.py
+++ b/src/test/python_tests/test_packaging.py
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Tests that bundled package metadata is intact.
+
+The extension ships bundled Python packages in ``bundled/libs/``.
+Some packages use ``importlib.metadata`` at runtime to resolve their
+version string, which requires the corresponding ``.dist-info``
+directory to be present.  These tests verify the metadata was not
+accidentally excluded.
+"""
+
+import importlib.metadata
+import pathlib
+import sys
+
+import pytest
+
+BUNDLED_LIBS = pathlib.Path(__file__).parent.parent.parent.parent / "bundled" / "libs"
+
+
+@pytest.fixture(autouse=True)
+def _ensure_bundled_on_path():
+    """Temporarily prepend ``bundled/libs`` to ``sys.path``."""
+    libs = str(BUNDLED_LIBS)
+    if libs not in sys.path:
+        sys.path.insert(0, libs)
+        yield
+        sys.path.remove(libs)
+    else:
+        yield
+
+
+def test_flake8_metadata_version():
+    """importlib.metadata must resolve the bundled flake8 version."""
+    version = importlib.metadata.version("flake8")
+    assert version, "flake8 version string should not be empty"
+    parts = version.split(".")
+    assert len(parts) >= 2, f"Unexpected version format: {version}"


### PR DESCRIPTION
## Problem

Bundled Python packages may use importlib.metadata at runtime to resolve their version string (e.g. isort 8.x uses importlib.metadata.version('isort') in _version.py). This is the modern standard recommended by PEP 566 / PEP 517.

The .vscodeignore has a blanket exclusion undled/libs/*.dist-info/** that strips all package metadata from the vsix. If any bundled dependency uses importlib.metadata, the LSP server crashes on startup with PackageNotFoundError.

This is currently affecting isort ([microsoft/vscode-isort#649](https://github.com/microsoft/vscode-isort/issues/649)) and is a preventive fix for this extension.

## Fix

Remove the undled/libs/*.dist-info/** exclusion. The size impact is negligible (~10-50 KB total) and this future-proofs against any bundled dependency switching to importlib.metadata for versioning.