### PR TITLE
Bump version to 2026.7.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "flake8",
     "displayName": "Flake8",
     "description": "%extension.description%",
-    "version": "2026.6.0",
+    "version": "2026.7.0-dev",
     "preview": true,
     "serverInfo": {
         "name": "Flake8",


### PR DESCRIPTION
Advance main to the next odd minor pre-release development version.