### PR TITLE
refactor: use shared logLegacySettings from common package

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ def _install_bundle(session: nox.Session) -> None:
         "--no-cache-dir",
         "--no-deps",
         "--upgrade",
-        "vscode-common-python-lsp==0.5.1",
+        "vscode-common-python-lsp==0.6.0",
     )
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "flake8",
-    "version": "2026.5.0-dev",
+    "version": "2026.7.0-dev",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flake8",
-            "version": "2026.5.0-dev",
+            "version": "2026.7.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "0.5.1",
+                "@vscode/common-python-lsp": "^0.6.0",
                 "@vscode/python-extension": "^1.0.6",
                 "vscode-languageclient": "^8.1.0"
             },
@@ -1037,6 +1037,7 @@
             "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.18.0",
                 "@typescript-eslint/types": "7.18.0",
@@ -1213,9 +1214,9 @@
             "license": "ISC"
         },
         "node_modules/@vscode/common-python-lsp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.5.1.tgz",
-            "integrity": "sha512-iJ7s0DyE1IZ1HSoDfTBHtVuf/jlXTqtKZDeD+m922gz5JAeiVSxg89dfTxDxxwEPAZXPG4kpNUjgWiFI3wTktA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.6.0.tgz",
+            "integrity": "sha512-wabQS/YK4qlZtU2/e2JrdvuuwyjVfvoPayCcpv3n+3Ii7+4yumrP6vZo/4zsnTUlapBzckOiSyGuwA5oODJGdg==",
             "license": "MIT",
             "dependencies": {
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
@@ -1775,6 +1776,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1821,6 +1823,7 @@
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -2112,6 +2115,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -3037,6 +3041,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -7151,6 +7156,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7372,6 +7378,7 @@
             "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -7420,6 +7427,7 @@
             "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.6.1",
                 "@webpack-cli/configtest": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
         ]
     },
     "dependencies": {
-        "@vscode/common-python-lsp": "0.5.1",
+        "@vscode/common-python-lsp": "^0.6.0",
         "@vscode/python-extension": "^1.0.6",
         "vscode-languageclient": "^8.1.0"
     },

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -27,6 +27,7 @@ export function logLegacySettings(): void {
         try {
             const legacyConfig = getConfiguration('python', workspace.uri);
             const legacyFlake8Enabled = legacyConfig.get<boolean>('linting.flake8Enabled', false);
+            const legacyFlake8Path = legacyConfig.get<string>('linting.flake8Path', '');
             if (legacyFlake8Enabled) {
                 traceWarn(`"python.linting.flake8Enabled" is deprecated. You can remove that setting.`);
                 traceWarn(
@@ -37,6 +38,11 @@ export function logLegacySettings(): void {
                     `"python.linting.flake8Enabled" value for workspace ${workspace.uri.fsPath}: ${legacyFlake8Enabled}`,
                 );
             }
+            if (legacyFlake8Path.length > 0 && legacyFlake8Path !== 'flake8') {
+                traceWarn(`"python.linting.flake8Path" is deprecated. Use "flake8.path" instead.`);
+                traceWarn(`"python.linting.flake8Path" value for workspace ${workspace.uri.fsPath}:`);
+                traceWarn(`\n${JSON.stringify(legacyFlake8Path, null, 4)}`);
+            }
         } catch (err) {
             traceWarn(`Error while logging legacy settings: ${err}`);
         }
@@ -46,6 +52,5 @@ export function logLegacySettings(): void {
     _logLegacySettings('flake8', [
         { legacyKey: 'linting.cwd', newKey: 'cwd' },
         { legacyKey: 'linting.flake8Args', newKey: 'args', isArray: true },
-        { legacyKey: 'linting.flake8Path', newKey: 'path' },
     ]);
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -27,7 +27,6 @@ export function logLegacySettings(): void {
         try {
             const legacyConfig = getConfiguration('python', workspace.uri);
             const legacyFlake8Enabled = legacyConfig.get<boolean>('linting.flake8Enabled', false);
-            const legacyFlake8Path = legacyConfig.get<string>('linting.flake8Path', '');
             if (legacyFlake8Enabled) {
                 traceWarn(`"python.linting.flake8Enabled" is deprecated. You can remove that setting.`);
                 traceWarn(
@@ -38,11 +37,6 @@ export function logLegacySettings(): void {
                     `"python.linting.flake8Enabled" value for workspace ${workspace.uri.fsPath}: ${legacyFlake8Enabled}`,
                 );
             }
-            if (legacyFlake8Path.length > 0 && legacyFlake8Path !== 'flake8') {
-                traceWarn(`"python.linting.flake8Path" is deprecated. Use "flake8.path" instead.`);
-                traceWarn(`"python.linting.flake8Path" value for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyFlake8Path, null, 4)}`);
-            }
         } catch (err) {
             traceWarn(`Error while logging legacy settings: ${err}`);
         }
@@ -52,5 +46,6 @@ export function logLegacySettings(): void {
     _logLegacySettings('flake8', [
         { legacyKey: 'linting.cwd', newKey: 'cwd' },
         { legacyKey: 'linting.flake8Args', newKey: 'args', isArray: true },
+        { legacyKey: 'linting.flake8Path', newKey: 'path', defaultValue: 'flake8' },
     ]);
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -4,7 +4,13 @@
 // Extension-specific settings: ISettings type extension and legacy settings logging.
 // All shared settings resolution is handled by @vscode/common-python-lsp directly.
 
-import { IBaseSettings, getConfiguration, getWorkspaceFolders, traceWarn } from '@vscode/common-python-lsp';
+import {
+    IBaseSettings,
+    getConfiguration,
+    getWorkspaceFolders,
+    logLegacySettings as _logLegacySettings,
+    traceWarn,
+} from '@vscode/common-python-lsp';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export interface ISettings extends IBaseSettings {
@@ -15,10 +21,11 @@ export interface ISettings extends IBaseSettings {
 }
 
 export function logLegacySettings(): void {
+    // Handle flake8Enabled separately — it has custom messaging not covered
+    // by the shared helper's simple "use X instead" pattern.
     getWorkspaceFolders().forEach((workspace) => {
         try {
             const legacyConfig = getConfiguration('python', workspace.uri);
-
             const legacyFlake8Enabled = legacyConfig.get<boolean>('linting.flake8Enabled', false);
             if (legacyFlake8Enabled) {
                 traceWarn(`"python.linting.flake8Enabled" is deprecated. You can remove that setting.`);
@@ -30,28 +37,15 @@ export function logLegacySettings(): void {
                     `"python.linting.flake8Enabled" value for workspace ${workspace.uri.fsPath}: ${legacyFlake8Enabled}`,
                 );
             }
-
-            const legacyCwd = legacyConfig.get<string>('linting.cwd');
-            if (legacyCwd) {
-                traceWarn(`"python.linting.cwd" is deprecated. Use "flake8.cwd" instead.`);
-                traceWarn(`"python.linting.cwd" value for workspace ${workspace.uri.fsPath}: ${legacyCwd}`);
-            }
-
-            const legacyArgs = legacyConfig.get<string[]>('linting.flake8Args', []);
-            if (legacyArgs.length > 0) {
-                traceWarn(`"python.linting.flake8Args" is deprecated. Use "flake8.args" instead.`);
-                traceWarn(`"python.linting.flake8Args" value for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyArgs, null, 4)}`);
-            }
-
-            const legacyPath = legacyConfig.get<string>('linting.flake8Path', '');
-            if (legacyPath.length > 0 && legacyPath !== 'flake8') {
-                traceWarn(`"python.linting.flake8Path" is deprecated. Use "flake8.path" instead.`);
-                traceWarn(`"python.linting.flake8Path" value for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyPath, null, 4)}`);
-            }
         } catch (err) {
             traceWarn(`Error while logging legacy settings: ${err}`);
         }
     });
+
+    // Standard legacy key → new key mappings handled by the shared helper.
+    _logLegacySettings('flake8', [
+        { legacyKey: 'linting.cwd', newKey: 'cwd' },
+        { legacyKey: 'linting.flake8Args', newKey: 'args', isArray: true },
+        { legacyKey: 'linting.flake8Path', newKey: 'path' },
+    ]);
 }


### PR DESCRIPTION
## Summary
Reduce code duplication between this extension and the shared package `@vscode/common-python-lsp` (`vscode-common-python-lsp`).

### Changes
- **`src/common/settings.ts`**: Use shared `logLegacySettings()` instead of inline legacy-setting migration warnings

### Impact
- Reduces duplicated code for legacy settings handling
- No behavioral changes — all existing functionality preserved
- No test modifications