### PR TITLE
Allow 'dependencies' label for required PR labels check

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: 'bug, debt, feature-request, no-changelog'
+          labels: 'bug, debt, feature-request, no-changelog, dependencies'


### PR DESCRIPTION
Adds the `dependencies` label to the list accepted by the `Ensure Required Labels` check in `pr-labels.yml`, so Dependabot PRs (labeled `dependencies`) satisfy the required-label gate.