### PR TITLE
Adopt vscode-common-python-lsp as a git submodule, synced via repository_dispatch, and stop Dependabot duplicates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,14 +13,14 @@ updates:
       npm-minor-patch:
         patterns:
           - '*'
-        # Exclude @vscode/common-python-lsp so it gets its own standalone PR (weekly).
-        exclude-patterns:
-          - '@vscode/common-python-lsp'
         update-types:
           - 'minor'
           - 'patch'
     open-pull-requests-limit: 10
     ignore:
+      # @vscode/common-python-lsp is handled by the shared-package-release
+      # dispatch workflow, so ignore it here to avoid duplicate PRs.
+      - dependency-name: '@vscode/common-python-lsp'
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'
       - dependency-name: 'vscode-languageclient'
@@ -39,12 +39,13 @@ updates:
       pip-minor-patch:
         patterns:
           - '*'
-        # Exclude vscode-common-python-lsp so it gets its own standalone PR (weekly).
-        exclude-patterns:
-          - 'vscode-common-python-lsp'
         update-types:
           - 'minor'
           - 'patch'
+    ignore:
+      # vscode-common-python-lsp is handled by the shared-package-release
+      # dispatch workflow, so ignore it here to avoid duplicate PRs.
+      - dependency-name: 'vscode-common-python-lsp'
 
   # Python test dependencies are updated weekly, minor updates are grouped (1 PR "pip-test-minor-patch").
   - package-ecosystem: 'pip'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,10 @@ updates:
           - 'patch'
     open-pull-requests-limit: 10
     ignore:
-      # @vscode/common-python-lsp is handled by the shared-package-submodule-sync
-      # dispatch workflow, so ignore it here to avoid duplicate PRs.
+      # Defensive no-op: @vscode/common-python-lsp is a `file:` submodule dep,
+      # which Dependabot never bumps. It is synced by the
+      # shared-package-submodule-sync dispatch workflow instead. Kept here to
+      # document intent should the dependency form ever change.
       - dependency-name: '@vscode/common-python-lsp'
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'
@@ -43,8 +45,9 @@ updates:
           - 'minor'
           - 'patch'
     ignore:
-      # vscode-common-python-lsp is handled by the shared-package-submodule-sync
-      # dispatch workflow, so ignore it here to avoid duplicate PRs.
+      # Defensive no-op: the pip `vscode-common-python-lsp` pin was removed from
+      # requirements when the shared package moved to the git submodule, so
+      # Dependabot has nothing to bump. Kept to document intent.
       - dependency-name: 'vscode-common-python-lsp'
 
   # Python test dependencies are updated weekly, minor updates are grouped (1 PR "pip-test-minor-patch").

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
           - 'patch'
     open-pull-requests-limit: 10
     ignore:
-      # @vscode/common-python-lsp is handled by the shared-package-release
+      # @vscode/common-python-lsp is handled by the shared-package-submodule-sync
       # dispatch workflow, so ignore it here to avoid duplicate PRs.
       - dependency-name: '@vscode/common-python-lsp'
       - dependency-name: '@types/vscode'
@@ -43,7 +43,7 @@ updates:
           - 'minor'
           - 'patch'
     ignore:
-      # vscode-common-python-lsp is handled by the shared-package-release
+      # vscode-common-python-lsp is handled by the shared-package-submodule-sync
       # dispatch workflow, so ignore it here to avoid duplicate PRs.
       - dependency-name: 'vscode-common-python-lsp'
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Build VSIX
         uses: ./.github/actions/build-vsix
@@ -31,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Lint
         uses: ./.github/actions/lint
@@ -54,6 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       # Install bundled libs using env.PYTHON_VERSION even though you test it on other versions.
@@ -106,6 +111,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       - name: Use Node.js ${{ env.NODE_VERSION }}

--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Build VSIX
         uses: ./.github/actions/build-vsix
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Lint
         uses: ./.github/actions/lint
@@ -62,6 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       # Install bundled libs using env.PYTHON_VERSION even though you test it on other versions.
@@ -115,6 +120,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       - name: Install Node

--- a/.github/workflows/shared-package-release.yml
+++ b/.github/workflows/shared-package-release.yml
@@ -8,9 +8,15 @@ permissions:
   contents: write
   issues: write
 
+concurrency:
+  group: 'shared-package-release-${{ github.event.client_payload.release_tag }}'
+  cancel-in-progress: false
+
 env:
   NODE_VERSION: 24.17.0
-  PYTHON_VERSION: '3.x'
+  # Match the Python version documented in requirements.in so the regenerated
+  # lockfile stays valid across the supported Python range.
+  PYTHON_VERSION: '3.9'
 
 jobs:
   update-shared-packages:
@@ -30,6 +36,20 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Validate dispatch payload
+        env:
+          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RELEASE_TAG}" ]; then
+            echo 'release_tag is missing from the dispatch payload.' >&2
+            exit 1
+          fi
+          if ! printf '%s' "${RELEASE_TAG}" | grep -Eq '^v?[0-9A-Za-z][0-9A-Za-z.+-]*$'; then
+            echo "release_tag '${RELEASE_TAG}' is not a valid version/ref." >&2
+            exit 1
+          fi
+
       - name: Normalize release tag
         id: release_version
         env:
@@ -46,6 +66,8 @@ jobs:
           set -euo pipefail
           BRANCH="shared-package-v${RELEASE_TAG#v}"
           git fetch origin main
+          # Fetch any pre-existing remote branch so --force-with-lease has a ref.
+          git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
           git checkout -B "$BRANCH" origin/main
 
       - name: Update npm dependency
@@ -75,10 +97,20 @@ jobs:
             exit 0
           fi
           python -m pip install --upgrade uv
-          sed -i -E "s/^${PIP_DEP}([<>=!~].*)?\$/${PIP_DEP}==${RELEASE_VERSION}/" requirements.in
-          uv pip compile --generate-hashes --upgrade -o requirements.txt requirements.in
+          # Rewrite the pin (case-insensitive) for the shared package only.
+          sed -i -E "s/^${PIP_DEP}([<>=!~].*)?\$/${PIP_DEP}==${RELEASE_VERSION}/I" requirements.in
+          if ! grep -iEq "^${PIP_DEP}==${RELEASE_VERSION}([[:space:];].*)?\$" requirements.in; then
+            echo "Failed to pin ${PIP_DEP}==${RELEASE_VERSION} in requirements.in." >&2
+            exit 1
+          fi
+          # Scope the re-resolve to the shared package and pin to the documented
+          # Python version so unrelated deps and version markers are preserved.
+          uv pip compile --generate-hashes \
+            --upgrade-package "${PIP_DEP}" \
+            --python-version "${PYTHON_VERSION}" \
+            -o requirements.txt requirements.in
 
-      - name: Commit branch and open tracking issue if changed
+      - name: Push branch and open tracking issue if changed
         env:
           RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
           RELEASE_URL: ${{ github.event.client_payload.release_url }}
@@ -95,8 +127,18 @@ jobs:
           BRANCH="shared-package-v${RELEASE_TAG#v}"
           git add -A
           git commit -m "Upgrade shared package to ${RELEASE_TAG}"
-          git push --set-upstream origin "$BRANCH"
+          git push --force-with-lease --set-upstream origin "$BRANCH"
           COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"
+          TITLE="[Shared Package] Open PR to upgrade to ${RELEASE_TAG}"
+          {
+            echo "### Shared package upgrade ready"
+            echo ''
+            echo "Branch \`${BRANCH}\` has been pushed."
+            echo ''
+            echo "[Open the pull request](${COMPARE_URL})"
+            echo ''
+            echo "Source release: ${RELEASE_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
           BODY_FILE="$(mktemp)"
           cat > "$BODY_FILE" <<EOF
           Branch \`${BRANCH}\` has been pushed with the shared package upgrade to ${RELEASE_TAG}.
@@ -107,6 +149,13 @@ jobs:
 
           Source release: ${RELEASE_URL}
           EOF
-          gh issue create \
-            --title "[Shared Package] Open PR to upgrade to ${RELEASE_TAG}" \
-            --body-file "$BODY_FILE"
+          # Reuse an existing open tracking issue for this release if present.
+          EXISTING="$(gh issue list --repo "$REPO" --state open --search "in:title ${TITLE}" --json number,title --jq "map(select(.title == \"${TITLE}\")) | .[0].number // empty" 2>/dev/null || true)"
+          if [ -n "${EXISTING}" ]; then
+            echo "Reusing existing tracking issue #${EXISTING}."
+            gh issue comment "${EXISTING}" --repo "$REPO" --body-file "$BODY_FILE" \
+              || echo 'Could not comment on issue; compare URL is in the job summary.'
+          else
+            gh issue create --repo "$REPO" --title "${TITLE}" --body-file "$BODY_FILE" \
+              || echo 'Could not create issue (Issues may be disabled); compare URL is in the job summary.'
+          fi

--- a/.github/workflows/shared-package-release.yml
+++ b/.github/workflows/shared-package-release.yml
@@ -75,25 +75,8 @@ jobs:
             exit 0
           fi
           python -m pip install --upgrade uv
-          python - <<'PY'
-          from pathlib import Path
-          import os
-          import re
-
-          dep = os.environ["PIP_DEP"]
-          version = os.environ["RELEASE_VERSION"]
-          pinned = f"{dep}=={version}"
-          req_in = Path("requirements.in")
-          txt = req_in.read_text(encoding="utf-8")
-          updated = re.sub(
-              rf"^{re.escape(dep)}([<>=!~].*)?$",
-              pinned,
-              txt,
-              flags=re.MULTILINE,
-          )
-          req_in.write_text(updated, encoding="utf-8")
-          PY
-          uv pip compile --generate-hashes ./requirements.in -o requirements.txt
+          sed -i -E "s/^${PIP_DEP}([<>=!~].*)?\$/${PIP_DEP}==${RELEASE_VERSION}/" requirements.in
+          uv pip compile --generate-hashes --upgrade -o requirements.txt requirements.in
 
       - name: Commit branch and open tracking issue if changed
         env:

--- a/.github/workflows/shared-package-release.yml
+++ b/.github/workflows/shared-package-release.yml
@@ -1,0 +1,129 @@
+name: Shared Package Release Handler
+
+on:
+  repository_dispatch:
+    types: [shared-package-release]
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  NODE_VERSION: 24.17.0
+  PYTHON_VERSION: '3.x'
+
+jobs:
+  update-shared-packages:
+    name: Update shared packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Normalize release tag
+        id: release_version
+        env:
+          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create branch for this release
+        env:
+          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+        run: |
+          set -euo pipefail
+          BRANCH="shared-package-v${RELEASE_TAG#v}"
+          git fetch origin main
+          git checkout -B "$BRANCH" origin/main
+
+      - name: Update npm dependency
+        env:
+          NPM_DEP: ${{ github.event.client_payload.npm_dependency }}
+          RELEASE_VERSION: ${{ steps.release_version.outputs.value }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NPM_DEP}" ]; then
+            echo 'No npm dependency in payload; skipping.'
+            exit 0
+          fi
+          npm install "${NPM_DEP}@${RELEASE_VERSION}"
+
+      - name: Update pip dependency
+        env:
+          PIP_DEP: ${{ github.event.client_payload.pip_dependency }}
+          RELEASE_VERSION: ${{ steps.release_version.outputs.value }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PIP_DEP}" ]; then
+            echo 'No pip dependency in payload; skipping.'
+            exit 0
+          fi
+          if [ ! -f requirements.in ]; then
+            echo 'No requirements.in found; skipping.'
+            exit 0
+          fi
+          python -m pip install --upgrade uv
+          python - <<'PY'
+          from pathlib import Path
+          import os
+          import re
+
+          dep = os.environ["PIP_DEP"]
+          version = os.environ["RELEASE_VERSION"]
+          pinned = f"{dep}=={version}"
+          req_in = Path("requirements.in")
+          txt = req_in.read_text(encoding="utf-8")
+          updated = re.sub(
+              rf"^{re.escape(dep)}([<>=!~].*)?$",
+              pinned,
+              txt,
+              flags=re.MULTILINE,
+          )
+          req_in.write_text(updated, encoding="utf-8")
+          PY
+          uv pip compile --generate-hashes ./requirements.in -o requirements.txt
+
+      - name: Commit branch and open tracking issue if changed
+        env:
+          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+          RELEASE_URL: ${{ github.event.client_payload.release_url }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          if git diff --quiet; then
+            echo 'No changes detected.'
+            exit 0
+          fi
+          BRANCH="shared-package-v${RELEASE_TAG#v}"
+          git add -A
+          git commit -m "Upgrade shared package to ${RELEASE_TAG}"
+          git push --set-upstream origin "$BRANCH"
+          COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"
+          BODY_FILE="$(mktemp)"
+          cat > "$BODY_FILE" <<EOF
+          Branch \`${BRANCH}\` has been pushed with the shared package upgrade to ${RELEASE_TAG}.
+
+          Organization settings prevent this workflow from opening pull requests automatically. Please open the PR manually:
+
+          ${COMPARE_URL}
+
+          Source release: ${RELEASE_URL}
+          EOF
+          gh issue create \
+            --title "[Shared Package] Open PR to upgrade to ${RELEASE_TAG}" \
+            --body-file "$BODY_FILE"

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -1,4 +1,4 @@
-name: Shared Package Release Handler
+name: Shared Package Submodule Sync
 
 on:
   repository_dispatch:
@@ -9,32 +9,22 @@ permissions:
   issues: write
 
 concurrency:
-  group: 'shared-package-release-${{ github.event.client_payload.release_tag }}'
+  group: 'shared-package-submodule-${{ github.event.client_payload.release_tag }}'
   cancel-in-progress: false
 
 env:
-  NODE_VERSION: 24.17.0
-  # Match the Python version documented in requirements.in so the regenerated
-  # lockfile stays valid across the supported Python range.
-  PYTHON_VERSION: '3.9'
+  SUBMODULE_PATH: external/vscode-common-python-lsp
 
 jobs:
-  update-shared-packages:
-    name: Update shared packages
+  update-submodule:
+    name: Update shared package submodule
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Install Node
-        uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          submodules: recursive
+          fetch-depth: 0
 
       - name: Validate dispatch payload
         env:
@@ -50,15 +40,6 @@ jobs:
             exit 1
           fi
 
-      - name: Normalize release tag
-        id: release_version
-        env:
-          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
-        run: |
-          set -euo pipefail
-          VERSION="${RELEASE_TAG#v}"
-          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Create branch for this release
         env:
           RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
@@ -69,46 +50,28 @@ jobs:
           # Fetch any pre-existing remote branch so --force-with-lease has a ref.
           git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
           git checkout -B "$BRANCH" origin/main
+          # Re-sync the submodule to whatever the freshly checked-out main records.
+          git submodule update --init --recursive "${SUBMODULE_PATH}"
 
-      - name: Update npm dependency
+      - name: Move submodule to the released commit
         env:
-          NPM_DEP: ${{ github.event.client_payload.npm_dependency }}
-          RELEASE_VERSION: ${{ steps.release_version.outputs.value }}
+          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
         run: |
           set -euo pipefail
-          if [ -z "${NPM_DEP}" ]; then
-            echo 'No npm dependency in payload; skipping.'
-            exit 0
+          cd "${SUBMODULE_PATH}"
+          git fetch --tags --force origin
+          STRIPPED="${RELEASE_TAG#v}"
+          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}^{commit}" >/dev/null; then
+            TARGET="refs/tags/${RELEASE_TAG}"
+          elif git rev-parse -q --verify "refs/tags/v${STRIPPED}^{commit}" >/dev/null; then
+            TARGET="refs/tags/v${STRIPPED}"
+          else
+            echo "Release tag '${RELEASE_TAG}' not found upstream; falling back to origin/main." >&2
+            git fetch origin main
+            TARGET="origin/main"
           fi
-          npm install "${NPM_DEP}@${RELEASE_VERSION}"
-
-      - name: Update pip dependency
-        env:
-          PIP_DEP: ${{ github.event.client_payload.pip_dependency }}
-          RELEASE_VERSION: ${{ steps.release_version.outputs.value }}
-        run: |
-          set -euo pipefail
-          if [ -z "${PIP_DEP}" ]; then
-            echo 'No pip dependency in payload; skipping.'
-            exit 0
-          fi
-          if [ ! -f requirements.in ]; then
-            echo 'No requirements.in found; skipping.'
-            exit 0
-          fi
-          python -m pip install --upgrade uv
-          # Rewrite the pin (case-insensitive) for the shared package only.
-          sed -i -E "s/^${PIP_DEP}([<>=!~].*)?\$/${PIP_DEP}==${RELEASE_VERSION}/I" requirements.in
-          if ! grep -iEq "^${PIP_DEP}==${RELEASE_VERSION}([[:space:];].*)?\$" requirements.in; then
-            echo "Failed to pin ${PIP_DEP}==${RELEASE_VERSION} in requirements.in." >&2
-            exit 1
-          fi
-          # Scope the re-resolve to the shared package and pin to the documented
-          # Python version so unrelated deps and version markers are preserved.
-          uv pip compile --generate-hashes \
-            --upgrade-package "${PIP_DEP}" \
-            --python-version "${PYTHON_VERSION}" \
-            -o requirements.txt requirements.in
+          echo "Checking out submodule at ${TARGET}."
+          git checkout --detach "${TARGET}"
 
       - name: Push branch and open tracking issue if changed
         env:
@@ -120,18 +83,19 @@ jobs:
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          if git diff --quiet; then
-            echo 'No changes detected.'
+          # Only the submodule gitlink should have moved.
+          if git diff --quiet -- "${SUBMODULE_PATH}"; then
+            echo 'Submodule already at the released commit; nothing to do.'
             exit 0
           fi
           BRANCH="shared-package-v${RELEASE_TAG#v}"
-          git add -A
-          git commit -m "Upgrade shared package to ${RELEASE_TAG}"
+          git add "${SUBMODULE_PATH}"
+          git commit -m "Update shared package submodule to ${RELEASE_TAG}"
           git push --force-with-lease --set-upstream origin "$BRANCH"
           COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"
-          TITLE="[Shared Package] Open PR to upgrade to ${RELEASE_TAG}"
+          TITLE="[Shared Package] Open PR to update submodule to ${RELEASE_TAG}"
           {
-            echo "### Shared package upgrade ready"
+            echo "### Shared package submodule update ready"
             echo ''
             echo "Branch \`${BRANCH}\` has been pushed."
             echo ''
@@ -141,7 +105,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           BODY_FILE="$(mktemp)"
           cat > "$BODY_FILE" <<EOF
-          Branch \`${BRANCH}\` has been pushed with the shared package upgrade to ${RELEASE_TAG}.
+          Branch \`${BRANCH}\` has been pushed, moving the \`${SUBMODULE_PATH}\` submodule to ${RELEASE_TAG}.
 
           Organization settings prevent this workflow from opening pull requests automatically. Please open the PR manually:
 

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -111,13 +111,28 @@ jobs:
             git checkout --detach "${TARGET}"
           )
 
-          # 4. Stop early if the submodule pointer did not move.
+          # 4. Guard against Python-version drift: the extension must not claim
+          #    support for an older Python than the shared package requires, or
+          #    the bundled library would fail to import at runtime.
+          EXT_MIN="$(sed -n 's/^python-\([0-9]\+\.[0-9]\+\).*/\1/p' runtime.txt | head -n1)"
+          PKG_FLOOR="$(sed -n 's/.*requires-python[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/p' "${SUBMODULE_PATH}/python/pyproject.toml" | head -n1)"
+          if [ -z "${EXT_MIN}" ] || [ -z "${PKG_FLOOR}" ]; then
+            echo "::error::Could not determine Python versions (extension runtime.txt='${EXT_MIN:-?}', shared package requires-python='${PKG_FLOOR:-?}')."
+            exit 1
+          fi
+          if [ "$(printf '%s\n%s\n' "${PKG_FLOOR}" "${EXT_MIN}" | sort -V | head -n1)" != "${PKG_FLOOR}" ]; then
+            echo "::error::Extension minimum Python (${EXT_MIN}, from runtime.txt) is older than the shared package floor (>=${PKG_FLOOR}). Raise runtime.txt, src/common/constants.ts and noxfile.py, or investigate the shared release before syncing."
+            exit 1
+          fi
+          echo "Python floors compatible: extension ${EXT_MIN} >= shared package ${PKG_FLOOR}."
+
+          # 5. Stop early if the submodule pointer did not move.
           if git diff --quiet -- "${SUBMODULE_PATH}"; then
             echo "Submodule already at ${RELEASE_TAG}; nothing to do."
             exit 0
           fi
 
-          # 5. Refresh the lockfile so the branch stays `npm ci`-mergeable, then
+          # 6. Refresh the lockfile so the branch stays `npm ci`-mergeable, then
           #    commit both the submodule pointer and the regenerated lockfile.
           npm install --package-lock-only --ignore-scripts
           git config user.name 'github-actions[bot]'
@@ -127,7 +142,7 @@ jobs:
           # New branch only (guarded above), so a plain push cannot overwrite work.
           retry git push --set-upstream origin "${BRANCH}"
 
-          # 6. Point a maintainer at the compare page via the job summary and a tracking issue.
+          # 7. Point a maintainer at the compare page via the job summary and a tracking issue.
           COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"
           TITLE="[Shared Package] Open PR to update submodule to ${RELEASE_TAG}"
           BODY_FILE="$(mktemp)"

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
       - name: Update submodule and open tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -48,9 +53,9 @@ jobs:
             done
           }
 
-          # 1. Validate the dispatch payload.
-          if ! printf '%s' "${RELEASE_TAG}" | grep -Eq '^v?[0-9A-Za-z][0-9A-Za-z.+-]*$'; then
-            echo "::error::release_tag '${RELEASE_TAG:-<empty>}' is missing or not a valid version/ref."
+          # 1. Validate the dispatch payload (require a real dotted version).
+          if ! printf '%s' "${RELEASE_TAG}" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+([-+.][0-9A-Za-z.+-]+)*$'; then
+            echo "::error::release_tag '${RELEASE_TAG:-<empty>}' is missing or not a valid semver release."
             exit 1
           fi
           VERSION="${RELEASE_TAG#v}"
@@ -59,8 +64,10 @@ jobs:
           # 2. Recreate the release branch from the latest main.
           retry git fetch origin main
           MAIN_SHA="$(git rev-parse FETCH_HEAD)"
-          # Make any pre-existing remote branch available so --force-with-lease has a ref.
+          # Record the current remote branch tip (if any) as an explicit lease
+          # baseline, so a concurrent update is not silently overwritten.
           git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
+          PRIOR_REMOTE="$(git rev-parse -q --verify "refs/remotes/origin/${BRANCH}" || true)"
           git checkout -B "${BRANCH}" "${MAIN_SHA}"
           git submodule update --init --recursive "${SUBMODULE_PATH}"
 
@@ -89,12 +96,18 @@ jobs:
             exit 0
           fi
 
-          # 5. Commit and push the branch.
+          # 5. Refresh the lockfile so the branch stays `npm ci`-mergeable, then
+          #    commit both the submodule pointer and the regenerated lockfile.
+          npm install --package-lock-only --ignore-scripts
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add "${SUBMODULE_PATH}"
+          git add "${SUBMODULE_PATH}" package-lock.json
           git commit -m "Update shared package submodule to ${RELEASE_TAG}"
-          retry git push --force-with-lease --set-upstream origin "${BRANCH}"
+          if [ -n "${PRIOR_REMOTE}" ]; then
+            retry git push --force-with-lease="${BRANCH}:${PRIOR_REMOTE}" --set-upstream origin "${BRANCH}"
+          else
+            retry git push --set-upstream origin "${BRANCH}"
+          fi
 
           # 6. Point a maintainer at the compare page via the job summary and a tracking issue.
           COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -190,7 +190,7 @@ jobs:
           # spec (e.g. "<3.14" or "==3.11.*") must not be misread as a floor, so
           # leave PKG_FLOOR empty (→ warn-and-skip below) when no lower bound exists.
           REQUIRES_PYTHON="$(sed -n 's/.*requires-python[[:space:]]*=[[:space:]]*["'\'']\([^"'\'']*\)["'\''].*/\1/p' "${SUBMODULE_PATH}/python/pyproject.toml" | head -n1)"
-          PKG_FLOOR="$(printf '%s' "${REQUIRES_PYTHON}" | grep -Eo '(>=|~=)[[:space:]]*[0-9]+\.[0-9]+' | grep -Eo '[0-9]+\.[0-9]+' | head -n1)"
+          PKG_FLOOR="$(printf '%s' "${REQUIRES_PYTHON}" | grep -Eo '(>=|~=)[[:space:]]*[0-9]+\.[0-9]+' | grep -Eo '[0-9]+\.[0-9]+' | head -n1 || true)"
           if [ -z "${PKG_FLOOR}" ]; then
             echo "::warning::Could not parse requires-python from the shared package; skipping the Python compatibility check."
           elif [ -z "${EXT_MIN}" ]; then
@@ -210,9 +210,9 @@ jobs:
         if: steps.guard.outputs.exists == 'false' && steps.detect.outputs.changed == 'true'
         run: |
           set -euo pipefail
-          EXT_NODE="$(grep -Eo '[0-9]+(\.[0-9]+)*' .nvmrc | head -n1)"
+          EXT_NODE="$(grep -Eo '[0-9]+(\.[0-9]+)*' .nvmrc | head -n1 || true)"
           PKG_RANGE="$(node -p "(require('./${SUBMODULE_PATH}/typescript/package.json').engines || {}).node || ''" 2>/dev/null || true)"
-          PKG_NODE="$(printf '%s' "${PKG_RANGE}" | grep -Eo '[0-9]+(\.[0-9]+)*' | head -n1)"
+          PKG_NODE="$(printf '%s' "${PKG_RANGE}" | grep -Eo '[0-9]+(\.[0-9]+)*' | head -n1 || true)"
           if [ -z "${PKG_NODE}" ]; then
             echo "::warning::Could not parse engines.node from the shared package; skipping the Node compatibility check."
           elif [ -z "${EXT_NODE}" ]; then

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -228,8 +228,12 @@ jobs:
 
       # Organization settings prevent opening PRs automatically, so point a
       # maintainer at the compare page via the job summary and a tracking issue.
+      # This also runs when the branch already exists so a re-dispatch after a
+      # partial failure (branch pushed but the notification never landed, or the
+      # issue was closed) re-ensures the maintainer notification instead of
+      # silently skipping it — the step is idempotent (it reuses any open issue).
       - name: Open or update the tracking issue
-        if: steps.guard.outputs.exists == 'false' && steps.detect.outputs.changed == 'true'
+        if: steps.guard.outputs.exists == 'true' || steps.detect.outputs.changed == 'true'
         run: |
           set -euo pipefail
           COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -143,6 +143,24 @@ jobs:
           fi
           echo "Python floors compatible: extension ${EXT_MIN} >= shared package ${PKG_FLOOR}."
 
+      # The extension builds the shared package's TypeScript during install, so
+      # its Node toolchain must be at least the version the shared package pins.
+      - name: Verify Node version compatibility
+        if: steps.guard.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
+          EXT_NODE="$(sed -n 's/^[[:space:]]*v\?\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' .nvmrc | head -n1)"
+          PKG_NODE="$(sed -n 's/^[[:space:]]*v\?\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' "${SUBMODULE_PATH}/.nvmrc" | head -n1)"
+          if [ -z "${EXT_NODE}" ] || [ -z "${PKG_NODE}" ]; then
+            echo "::error::Could not determine Node versions (extension .nvmrc='${EXT_NODE:-?}', shared package .nvmrc='${PKG_NODE:-?}')."
+            exit 1
+          fi
+          if [ "$(printf '%s\n%s\n' "${PKG_NODE}" "${EXT_NODE}" | sort -V | head -n1)" != "${PKG_NODE}" ]; then
+            echo "::error::Extension Node version (${EXT_NODE}, from .nvmrc) is older than the shared package's pinned Node (${PKG_NODE}). Update .nvmrc, or investigate the shared release before syncing."
+            exit 1
+          fi
+          echo "Node versions compatible: extension ${EXT_NODE} >= shared package ${PKG_NODE}."
+
       - name: Detect whether the submodule pointer moved
         id: detect
         if: steps.guard.outputs.exists == 'false'

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -85,17 +85,32 @@ jobs:
           echo "BASH_ENV=${HELPER}" >>"${GITHUB_ENV}"
 
       # Once the release branch exists a maintainer may be editing it, so the
-      # remaining steps are skipped to avoid clobbering their work.
+      # remaining steps are skipped to avoid clobbering their work. A transient
+      # ls-remote failure must not be mistaken for "branch absent", so retry and
+      # only treat a definitive "no such ref" (exit code 2) as missing.
       - name: Check whether the release branch already exists
         id: guard
         run: |
           set -euo pipefail
-          if git ls-remote --exit-code --heads origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
-            echo "Branch ${BRANCH} already exists; leaving it untouched."
-            echo 'exists=true' >>"${GITHUB_OUTPUT}"
-          else
-            echo 'exists=false' >>"${GITHUB_OUTPUT}"
+          exists=''
+          for attempt in 1 2 3; do
+            set +e
+            git ls-remote --exit-code --heads origin "refs/heads/${BRANCH}" >/dev/null 2>&1
+            rc=$?
+            set -e
+            if [ "${rc}" -eq 0 ]; then exists=true; break; fi
+            if [ "${rc}" -eq 2 ]; then exists=false; break; fi
+            echo "ls-remote failed (exit ${rc}); attempt ${attempt}/3..." >&2
+            sleep $((attempt * 5))
+          done
+          if [ -z "${exists}" ]; then
+            echo "::error::Could not reach origin to check for ${BRANCH} after 3 attempts."
+            exit 1
           fi
+          if [ "${exists}" = 'true' ]; then
+            echo "Branch ${BRANCH} already exists; leaving it untouched."
+          fi
+          echo "exists=${exists}" >>"${GITHUB_OUTPUT}"
 
       - name: Create the release branch from the latest main
         if: steps.guard.outputs.exists == 'false'
@@ -125,42 +140,9 @@ jobs:
           echo "Checking out submodule at ${TARGET}."
           git checkout --detach "${TARGET}"
 
-      # The extension must not claim support for an older Python than the shared
-      # package requires, or the bundled library would fail to import at runtime.
-      - name: Verify Python version compatibility
-        if: steps.guard.outputs.exists == 'false'
-        run: |
-          set -euo pipefail
-          EXT_MIN="$(sed -n 's/^python-\([0-9]\+\.[0-9]\+\).*/\1/p' runtime.txt | head -n1)"
-          PKG_FLOOR="$(sed -n 's/.*requires-python[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/p' "${SUBMODULE_PATH}/python/pyproject.toml" | head -n1)"
-          if [ -z "${EXT_MIN}" ] || [ -z "${PKG_FLOOR}" ]; then
-            echo "::error::Could not determine Python versions (extension runtime.txt='${EXT_MIN:-?}', shared package requires-python='${PKG_FLOOR:-?}')."
-            exit 1
-          fi
-          if [ "$(printf '%s\n%s\n' "${PKG_FLOOR}" "${EXT_MIN}" | sort -V | head -n1)" != "${PKG_FLOOR}" ]; then
-            echo "::error::Extension minimum Python (${EXT_MIN}, from runtime.txt) is older than the shared package floor (>=${PKG_FLOOR}). Raise runtime.txt, src/common/constants.ts and noxfile.py, or investigate the shared release before syncing."
-            exit 1
-          fi
-          echo "Python floors compatible: extension ${EXT_MIN} >= shared package ${PKG_FLOOR}."
-
-      # The extension builds the shared package's TypeScript during install, so
-      # its Node toolchain must be at least the version the shared package pins.
-      - name: Verify Node version compatibility
-        if: steps.guard.outputs.exists == 'false'
-        run: |
-          set -euo pipefail
-          EXT_NODE="$(sed -n 's/^[[:space:]]*v\?\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' .nvmrc | head -n1)"
-          PKG_NODE="$(sed -n 's/^[[:space:]]*v\?\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' "${SUBMODULE_PATH}/.nvmrc" | head -n1)"
-          if [ -z "${EXT_NODE}" ] || [ -z "${PKG_NODE}" ]; then
-            echo "::error::Could not determine Node versions (extension .nvmrc='${EXT_NODE:-?}', shared package .nvmrc='${PKG_NODE:-?}')."
-            exit 1
-          fi
-          if [ "$(printf '%s\n%s\n' "${PKG_NODE}" "${EXT_NODE}" | sort -V | head -n1)" != "${PKG_NODE}" ]; then
-            echo "::error::Extension Node version (${EXT_NODE}, from .nvmrc) is older than the shared package's pinned Node (${PKG_NODE}). Update .nvmrc, or investigate the shared release before syncing."
-            exit 1
-          fi
-          echo "Node versions compatible: extension ${EXT_NODE} >= shared package ${PKG_NODE}."
-
+      # Determine whether the release actually moves the submodule before running
+      # the compatibility guards, so a no-op re-dispatch exits cleanly instead of
+      # doing extra work or failing loudly with nothing to sync.
       - name: Detect whether the submodule pointer moved
         id: detect
         if: steps.guard.outputs.exists == 'false'
@@ -173,6 +155,50 @@ jobs:
             echo 'changed=true' >>"${GITHUB_OUTPUT}"
           fi
 
+      # The extension must not claim support for an older Python than the shared
+      # package requires, or the bundled library would fail to import at runtime.
+      # Compare the package floor against the extension's *declared* minimum in
+      # src/common/constants.ts (not the bundling interpreter in runtime.txt); an
+      # unparseable floor only warns so upstream repackaging can't wedge the sync.
+      - name: Verify Python version compatibility
+        if: steps.guard.outputs.exists == 'false' && steps.detect.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          EXT_MIN="$(sed -n 's/.*minimumPythonVersion:[[:space:]]*{[[:space:]]*major:[[:space:]]*\([0-9]\+\)[[:space:]]*,[[:space:]]*minor:[[:space:]]*\([0-9]\+\).*/\1.\2/p' src/common/constants.ts | head -n1)"
+          PKG_FLOOR="$(sed -n 's/.*requires-python[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/p' "${SUBMODULE_PATH}/python/pyproject.toml" | head -n1)"
+          if [ -z "${PKG_FLOOR}" ]; then
+            echo "::warning::Could not parse requires-python from the shared package; skipping the Python compatibility check."
+          elif [ -z "${EXT_MIN}" ]; then
+            echo "::warning::Could not parse minimumPythonVersion from src/common/constants.ts; skipping the Python compatibility check."
+          elif [ "$(printf '%s\n%s\n' "${PKG_FLOOR}" "${EXT_MIN}" | sort -V | head -n1)" != "${PKG_FLOOR}" ]; then
+            echo "::error::Extension minimum Python (${EXT_MIN}, from src/common/constants.ts) is older than the shared package floor (>=${PKG_FLOOR}). Raise the minimum in src/common/constants.ts, runtime.txt and noxfile.py, or investigate the shared release before syncing."
+            exit 1
+          else
+            echo "Python floors compatible: extension ${EXT_MIN} >= shared package ${PKG_FLOOR}."
+          fi
+
+      # The extension builds the shared package's TypeScript during install, so its
+      # Node toolchain must satisfy the package's declared build floor
+      # (engines.node), not the exact dev pin in the submodule .nvmrc. An
+      # unparseable floor only warns rather than failing every future sync.
+      - name: Verify Node version compatibility
+        if: steps.guard.outputs.exists == 'false' && steps.detect.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          EXT_NODE="$(grep -Eo '[0-9]+(\.[0-9]+)*' .nvmrc | head -n1)"
+          PKG_RANGE="$(node -p "(require('./${SUBMODULE_PATH}/typescript/package.json').engines || {}).node || ''" 2>/dev/null || true)"
+          PKG_NODE="$(printf '%s' "${PKG_RANGE}" | grep -Eo '[0-9]+(\.[0-9]+)*' | head -n1)"
+          if [ -z "${PKG_NODE}" ]; then
+            echo "::warning::Could not parse engines.node from the shared package; skipping the Node compatibility check."
+          elif [ -z "${EXT_NODE}" ]; then
+            echo "::warning::Could not parse a Node version from .nvmrc; skipping the Node compatibility check."
+          elif [ "$(printf '%s\n%s\n' "${PKG_NODE}" "${EXT_NODE}" | sort -V | head -n1)" != "${PKG_NODE}" ]; then
+            echo "::error::Extension Node version (${EXT_NODE}, from .nvmrc) is older than the shared package's required build floor (>=${PKG_NODE}, from engines.node). Update .nvmrc, or investigate the shared release before syncing."
+            exit 1
+          else
+            echo "Node versions compatible: extension ${EXT_NODE} >= shared package build floor ${PKG_NODE}."
+          fi
+
       # Refresh the lockfile so the branch stays `npm ci`-mergeable, then commit
       # both the submodule pointer and the regenerated lockfile. The branch is
       # new (guarded above), so a plain push cannot overwrite anyone's work.
@@ -180,7 +206,7 @@ jobs:
         if: steps.guard.outputs.exists == 'false' && steps.detect.outputs.changed == 'true'
         run: |
           set -euo pipefail
-          npm install --package-lock-only --ignore-scripts
+          retry npm install --package-lock-only --ignore-scripts
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add "${SUBMODULE_PATH}" package-lock.json

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -247,14 +247,16 @@ jobs:
             echo "Source release: ${RELEASE_URL:-n/a}"
           } | tee -a "$GITHUB_STEP_SUMMARY" >"$BODY_FILE"
 
+          # Quote the title in the search so the bracketed "[Shared Package]"
+          # prefix is matched as a phrase rather than tokenized, and do not
+          # swallow gh errors: a failed lookup must surface (set -e) rather than
+          # silently fall through and create a duplicate tracking issue.
           EXISTING="$(gh issue list --repo "$REPO" --state open \
-            --search "in:title ${TITLE}" --json number,title \
-            --jq "map(select(.title == \"${TITLE}\")) | .[0].number // empty" 2>/dev/null || true)"
+            --search "\"${TITLE}\" in:title" --json number,title \
+            --jq "map(select(.title == \"${TITLE}\")) | .[0].number // empty")"
           if [ -n "${EXISTING}" ]; then
             echo "Reusing existing tracking issue #${EXISTING}."
-            gh issue comment "${EXISTING}" --repo "$REPO" --body-file "$BODY_FILE" \
-              || echo 'Could not comment on the tracking issue; the compare URL is in the job summary.'
+            gh issue comment "${EXISTING}" --repo "$REPO" --body-file "$BODY_FILE"
           else
-            gh issue create --repo "$REPO" --title "${TITLE}" --body-file "$BODY_FILE" \
-              || echo 'Could not create the tracking issue; the compare URL is in the job summary.'
+            gh issue create --repo "$REPO" --title "${TITLE}" --body-file "$BODY_FILE"
           fi

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -127,7 +127,7 @@ jobs:
           set -euo pipefail
           retry git fetch --tags --force origin
           TARGET=''
-          for CANDIDATE in "refs/tags/${RELEASE_TAG}" "refs/tags/v${VERSION}"; do
+          for CANDIDATE in "refs/tags/${RELEASE_TAG}" "refs/tags/v${VERSION}" "refs/tags/${VERSION}"; do
             if git rev-parse -q --verify "${CANDIDATE}^{commit}" >/dev/null; then
               TARGET="${CANDIDATE}"
               break

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -31,9 +31,18 @@ jobs:
             exit 1
           fi
           VERSION="${RELEASE_TAG#v}"
+          BRANCH="shared-package-v${VERSION}"
+          # The regex above matches per line, so a multi-line tag (or a "+build"
+          # segment containing "..") can slip through and taint the branch/ref
+          # name. Reject anything git itself considers a malformed ref before it
+          # is emitted as an output.
+          if ! git check-ref-format "refs/heads/${BRANCH}"; then
+            echo "::error::Computed branch name 'refs/heads/${BRANCH}' is not a valid git ref."
+            exit 1
+          fi
           {
             echo "version=${VERSION}"
-            echo "branch=shared-package-v${VERSION}"
+            echo "branch=${BRANCH}"
           } >>"$GITHUB_OUTPUT"
 
   sync:

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -8,22 +8,52 @@ permissions:
   contents: write
   issues: write
 
-concurrency:
-  group: 'shared-package-submodule-${{ github.event.client_payload.release_tag }}'
-  cancel-in-progress: false
-
 env:
   SUBMODULE_PATH: external/vscode-common-python-lsp
-  RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
-  RELEASE_URL: ${{ github.event.client_payload.release_url }}
 
 jobs:
-  update-submodule:
-    name: Update shared package submodule
+  prepare:
+    name: Validate and normalize the release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.normalize.outputs.version }}
+      branch: ${{ steps.normalize.outputs.branch }}
+    steps:
+      - name: Normalize release tag
+        id: normalize
+        env:
+          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+        run: |
+          set -euo pipefail
+          # Require a real dotted release so a branch/ref name can never be malformed.
+          if ! printf '%s' "${RELEASE_TAG}" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.]+)*$'; then
+            echo "::error::release_tag '${RELEASE_TAG:-<empty>}' is missing or not a valid semver release."
+            exit 1
+          fi
+          VERSION="${RELEASE_TAG#v}"
+          {
+            echo "version=${VERSION}"
+            echo "branch=shared-package-v${VERSION}"
+          } >>"$GITHUB_OUTPUT"
+
+  sync:
+    name: Update shared package submodule
+    needs: prepare
+    runs-on: ubuntu-latest
+    # Key on the normalized branch so `v1.2.3` and `1.2.3` share one group.
+    concurrency:
+      group: shared-package-submodule-${{ needs.prepare.outputs.branch }}
+      cancel-in-progress: false
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
+      BRANCH: ${{ needs.prepare.outputs.branch }}
+      RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+      RELEASE_URL: ${{ github.event.client_payload.release_url }}
+      REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -33,9 +63,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Update submodule and open tracking issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
@@ -53,22 +80,16 @@ jobs:
             done
           }
 
-          # 1. Validate the dispatch payload (require a real dotted version).
-          if ! printf '%s' "${RELEASE_TAG}" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+([-+.][0-9A-Za-z.+-]+)*$'; then
-            echo "::error::release_tag '${RELEASE_TAG:-<empty>}' is missing or not a valid semver release."
-            exit 1
+          # 1. Never clobber an existing release branch: once it exists a
+          #    maintainer may be editing it, so this workflow leaves it alone.
+          if git ls-remote --exit-code --heads origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
+            echo "Branch ${BRANCH} already exists; leaving it untouched."
+            exit 0
           fi
-          VERSION="${RELEASE_TAG#v}"
-          BRANCH="shared-package-v${VERSION}"
 
-          # 2. Recreate the release branch from the latest main.
+          # 2. Build the release branch from the latest main.
           retry git fetch origin main
-          MAIN_SHA="$(git rev-parse FETCH_HEAD)"
-          # Record the current remote branch tip (if any) as an explicit lease
-          # baseline, so a concurrent update is not silently overwritten.
-          git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
-          PRIOR_REMOTE="$(git rev-parse -q --verify "refs/remotes/origin/${BRANCH}" || true)"
-          git checkout -B "${BRANCH}" "${MAIN_SHA}"
+          git checkout -B "${BRANCH}" FETCH_HEAD
           git submodule update --init --recursive "${SUBMODULE_PATH}"
 
           # 3. Move the submodule to the released commit (fail if the tag is unknown).
@@ -103,11 +124,8 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add "${SUBMODULE_PATH}" package-lock.json
           git commit -m "Update shared package submodule to ${RELEASE_TAG}"
-          if [ -n "${PRIOR_REMOTE}" ]; then
-            retry git push --force-with-lease="${BRANCH}:${PRIOR_REMOTE}" --set-upstream origin "${BRANCH}"
-          else
-            retry git push --set-upstream origin "${BRANCH}"
-          fi
+          # New branch only (guarded above), so a plain push cannot overwrite work.
+          retry git push --set-upstream origin "${BRANCH}"
 
           # 6. Point a maintainer at the compare page via the job summary and a tracking issue.
           COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -14,6 +14,8 @@ concurrency:
 
 env:
   SUBMODULE_PATH: external/vscode-common-python-lsp
+  RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+  RELEASE_URL: ${{ github.event.client_payload.release_url }}
 
 jobs:
   update-submodule:
@@ -24,102 +26,101 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-          fetch-depth: 0
 
-      - name: Validate dispatch payload
+      - name: Update submodule and open tracking issue
         env:
-          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if [ -z "${RELEASE_TAG}" ]; then
-            echo 'release_tag is missing from the dispatch payload.' >&2
-            exit 1
-          fi
+
+          # Retry wrapper for flaky network operations (fetch/push).
+          retry() {
+            local attempt=1
+            until "$@"; do
+              if [ "${attempt}" -ge 3 ]; then
+                echo "::error::Command failed after ${attempt} attempts: $*"
+                return 1
+              fi
+              echo "Attempt ${attempt} failed: $* — retrying..." >&2
+              attempt=$((attempt + 1))
+              sleep $((attempt * 5))
+            done
+          }
+
+          # 1. Validate the dispatch payload.
           if ! printf '%s' "${RELEASE_TAG}" | grep -Eq '^v?[0-9A-Za-z][0-9A-Za-z.+-]*$'; then
-            echo "release_tag '${RELEASE_TAG}' is not a valid version/ref." >&2
+            echo "::error::release_tag '${RELEASE_TAG:-<empty>}' is missing or not a valid version/ref."
             exit 1
           fi
+          VERSION="${RELEASE_TAG#v}"
+          BRANCH="shared-package-v${VERSION}"
 
-      - name: Create branch for this release
-        env:
-          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
-        run: |
-          set -euo pipefail
-          BRANCH="shared-package-v${RELEASE_TAG#v}"
-          git fetch origin main
-          # Fetch any pre-existing remote branch so --force-with-lease has a ref.
+          # 2. Recreate the release branch from the latest main.
+          retry git fetch origin main
+          MAIN_SHA="$(git rev-parse FETCH_HEAD)"
+          # Make any pre-existing remote branch available so --force-with-lease has a ref.
           git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
-          git checkout -B "$BRANCH" origin/main
-          # Re-sync the submodule to whatever the freshly checked-out main records.
+          git checkout -B "${BRANCH}" "${MAIN_SHA}"
           git submodule update --init --recursive "${SUBMODULE_PATH}"
 
-      - name: Move submodule to the released commit
-        env:
-          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
-        run: |
-          set -euo pipefail
-          cd "${SUBMODULE_PATH}"
-          git fetch --tags --force origin
-          STRIPPED="${RELEASE_TAG#v}"
-          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}^{commit}" >/dev/null; then
-            TARGET="refs/tags/${RELEASE_TAG}"
-          elif git rev-parse -q --verify "refs/tags/v${STRIPPED}^{commit}" >/dev/null; then
-            TARGET="refs/tags/v${STRIPPED}"
-          else
-            echo "Release tag '${RELEASE_TAG}' not found upstream; falling back to origin/main." >&2
-            git fetch origin main
-            TARGET="origin/main"
-          fi
-          echo "Checking out submodule at ${TARGET}."
-          git checkout --detach "${TARGET}"
+          # 3. Move the submodule to the released commit (fail if the tag is unknown).
+          (
+            cd "${SUBMODULE_PATH}"
+            retry git fetch --tags --force origin
+            TARGET=''
+            for CANDIDATE in "refs/tags/${RELEASE_TAG}" "refs/tags/v${VERSION}"; do
+              if git rev-parse -q --verify "${CANDIDATE}^{commit}" >/dev/null; then
+                TARGET="${CANDIDATE}"
+                break
+              fi
+            done
+            if [ -z "${TARGET}" ]; then
+              echo "::error::Release tag '${RELEASE_TAG}' was not found in the shared package repository."
+              exit 1
+            fi
+            echo "Checking out submodule at ${TARGET}."
+            git checkout --detach "${TARGET}"
+          )
 
-      - name: Push branch and open tracking issue if changed
-        env:
-          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
-          RELEASE_URL: ${{ github.event.client_payload.release_url }}
-          REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          # Only the submodule gitlink should have moved.
+          # 4. Stop early if the submodule pointer did not move.
           if git diff --quiet -- "${SUBMODULE_PATH}"; then
-            echo 'Submodule already at the released commit; nothing to do.'
+            echo "Submodule already at ${RELEASE_TAG}; nothing to do."
             exit 0
           fi
-          BRANCH="shared-package-v${RELEASE_TAG#v}"
+
+          # 5. Commit and push the branch.
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add "${SUBMODULE_PATH}"
           git commit -m "Update shared package submodule to ${RELEASE_TAG}"
-          git push --force-with-lease --set-upstream origin "$BRANCH"
+          retry git push --force-with-lease --set-upstream origin "${BRANCH}"
+
+          # 6. Point a maintainer at the compare page via the job summary and a tracking issue.
           COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"
           TITLE="[Shared Package] Open PR to update submodule to ${RELEASE_TAG}"
+          BODY_FILE="$(mktemp)"
           {
             echo "### Shared package submodule update ready"
             echo ''
-            echo "Branch \`${BRANCH}\` has been pushed."
+            echo "Branch \`${BRANCH}\` has been pushed, moving \`${SUBMODULE_PATH}\` to ${RELEASE_TAG}."
+            echo ''
+            echo 'Organization settings prevent this workflow from opening pull requests automatically. Please open it manually:'
             echo ''
             echo "[Open the pull request](${COMPARE_URL})"
             echo ''
-            echo "Source release: ${RELEASE_URL}"
-          } >> "$GITHUB_STEP_SUMMARY"
-          BODY_FILE="$(mktemp)"
-          cat > "$BODY_FILE" <<EOF
-          Branch \`${BRANCH}\` has been pushed, moving the \`${SUBMODULE_PATH}\` submodule to ${RELEASE_TAG}.
+            echo "Source release: ${RELEASE_URL:-n/a}"
+          } | tee -a "$GITHUB_STEP_SUMMARY" >"$BODY_FILE"
 
-          Organization settings prevent this workflow from opening pull requests automatically. Please open the PR manually:
-
-          ${COMPARE_URL}
-
-          Source release: ${RELEASE_URL}
-          EOF
           # Reuse an existing open tracking issue for this release if present.
-          EXISTING="$(gh issue list --repo "$REPO" --state open --search "in:title ${TITLE}" --json number,title --jq "map(select(.title == \"${TITLE}\")) | .[0].number // empty" 2>/dev/null || true)"
+          EXISTING="$(gh issue list --repo "$REPO" --state open \
+            --search "in:title ${TITLE}" --json number,title \
+            --jq "map(select(.title == \"${TITLE}\")) | .[0].number // empty" 2>/dev/null || true)"
           if [ -n "${EXISTING}" ]; then
             echo "Reusing existing tracking issue #${EXISTING}."
             gh issue comment "${EXISTING}" --repo "$REPO" --body-file "$BODY_FILE" \
-              || echo 'Could not comment on issue; compare URL is in the job summary.'
+              || echo 'Could not comment on the tracking issue; the compare URL is in the job summary.'
           else
             gh issue create --repo "$REPO" --title "${TITLE}" --body-file "$BODY_FILE" \
-              || echo 'Could not create issue (Issues may be disabled); compare URL is in the job summary.'
+              || echo 'Could not create the tracking issue; the compare URL is in the job summary.'
           fi

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -174,6 +174,18 @@ jobs:
         run: |
           set -euo pipefail
           EXT_MIN="$(sed -n 's/.*minimumPythonVersion:[[:space:]]*{[[:space:]]*major:[[:space:]]*\([0-9]\+\)[[:space:]]*,[[:space:]]*minor:[[:space:]]*\([0-9]\+\).*/\1.\2/p' src/common/constants.ts | head -n1)"
+          # Some extensions declare the floor with symbolic constants
+          # (minimumPythonVersion: { major: MINIMUM_PYTHON_MAJOR, minor: MINIMUM_PYTHON_MINOR }),
+          # so the inline-literal parse above finds nothing. Fall back to the
+          # numeric MINIMUM_PYTHON_MAJOR/MINOR definitions before giving up, or
+          # the gate silently passes on those repos.
+          if [ -z "${EXT_MIN}" ]; then
+            EXT_MAJOR="$(sed -n 's/.*MINIMUM_PYTHON_MAJOR[[:space:]]*=[[:space:]]*\([0-9]\+\).*/\1/p' src/common/constants.ts | head -n1)"
+            EXT_MINOR="$(sed -n 's/.*MINIMUM_PYTHON_MINOR[[:space:]]*=[[:space:]]*\([0-9]\+\).*/\1/p' src/common/constants.ts | head -n1)"
+            if [ -n "${EXT_MAJOR}" ] && [ -n "${EXT_MINOR}" ]; then
+              EXT_MIN="${EXT_MAJOR}.${EXT_MINOR}"
+            fi
+          fi
           # Read only a >=/~= lower bound from requires-python; an upper-bound-only
           # spec (e.g. "<3.14" or "==3.11.*") must not be misread as a floor, so
           # leave PKG_FLOOR empty (→ warn-and-skip below) when no lower bound exists.

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -62,11 +62,13 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Update submodule and open tracking issue
+      # Expose a `retry` helper to every later bash step via BASH_ENV so the
+      # network operations below (fetch/push) stay readable one-liners.
+      - name: Set up the git retry helper
         run: |
           set -euo pipefail
-
-          # Retry wrapper for flaky network operations (fetch/push).
+          HELPER="${RUNNER_TEMP}/helpers.sh"
+          cat >"${HELPER}" <<'SH'
           retry() {
             local attempt=1
             until "$@"; do
@@ -79,41 +81,56 @@ jobs:
               sleep $((attempt * 5))
             done
           }
+          SH
+          echo "BASH_ENV=${HELPER}" >>"${GITHUB_ENV}"
 
-          # 1. Never clobber an existing release branch: once it exists a
-          #    maintainer may be editing it, so this workflow leaves it alone.
+      # Once the release branch exists a maintainer may be editing it, so the
+      # remaining steps are skipped to avoid clobbering their work.
+      - name: Check whether the release branch already exists
+        id: guard
+        run: |
+          set -euo pipefail
           if git ls-remote --exit-code --heads origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
             echo "Branch ${BRANCH} already exists; leaving it untouched."
-            exit 0
+            echo 'exists=true' >>"${GITHUB_OUTPUT}"
+          else
+            echo 'exists=false' >>"${GITHUB_OUTPUT}"
           fi
 
-          # 2. Build the release branch from the latest main.
+      - name: Create the release branch from the latest main
+        if: steps.guard.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
           retry git fetch origin main
           git checkout -B "${BRANCH}" FETCH_HEAD
           git submodule update --init --recursive "${SUBMODULE_PATH}"
 
-          # 3. Move the submodule to the released commit (fail if the tag is unknown).
-          (
-            cd "${SUBMODULE_PATH}"
-            retry git fetch --tags --force origin
-            TARGET=''
-            for CANDIDATE in "refs/tags/${RELEASE_TAG}" "refs/tags/v${VERSION}"; do
-              if git rev-parse -q --verify "${CANDIDATE}^{commit}" >/dev/null; then
-                TARGET="${CANDIDATE}"
-                break
-              fi
-            done
-            if [ -z "${TARGET}" ]; then
-              echo "::error::Release tag '${RELEASE_TAG}' was not found in the shared package repository."
-              exit 1
+      - name: Point the submodule at the released commit
+        if: steps.guard.outputs.exists == 'false'
+        working-directory: ${{ env.SUBMODULE_PATH }}
+        run: |
+          set -euo pipefail
+          retry git fetch --tags --force origin
+          TARGET=''
+          for CANDIDATE in "refs/tags/${RELEASE_TAG}" "refs/tags/v${VERSION}"; do
+            if git rev-parse -q --verify "${CANDIDATE}^{commit}" >/dev/null; then
+              TARGET="${CANDIDATE}"
+              break
             fi
-            echo "Checking out submodule at ${TARGET}."
-            git checkout --detach "${TARGET}"
-          )
+          done
+          if [ -z "${TARGET}" ]; then
+            echo "::error::Release tag '${RELEASE_TAG}' was not found in the shared package repository."
+            exit 1
+          fi
+          echo "Checking out submodule at ${TARGET}."
+          git checkout --detach "${TARGET}"
 
-          # 4. Guard against Python-version drift: the extension must not claim
-          #    support for an older Python than the shared package requires, or
-          #    the bundled library would fail to import at runtime.
+      # The extension must not claim support for an older Python than the shared
+      # package requires, or the bundled library would fail to import at runtime.
+      - name: Verify Python version compatibility
+        if: steps.guard.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
           EXT_MIN="$(sed -n 's/^python-\([0-9]\+\.[0-9]\+\).*/\1/p' runtime.txt | head -n1)"
           PKG_FLOOR="$(sed -n 's/.*requires-python[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/p' "${SUBMODULE_PATH}/python/pyproject.toml" | head -n1)"
           if [ -z "${EXT_MIN}" ] || [ -z "${PKG_FLOOR}" ]; then
@@ -126,23 +143,38 @@ jobs:
           fi
           echo "Python floors compatible: extension ${EXT_MIN} >= shared package ${PKG_FLOOR}."
 
-          # 5. Stop early if the submodule pointer did not move.
+      - name: Detect whether the submodule pointer moved
+        id: detect
+        if: steps.guard.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
           if git diff --quiet -- "${SUBMODULE_PATH}"; then
             echo "Submodule already at ${RELEASE_TAG}; nothing to do."
-            exit 0
+            echo 'changed=false' >>"${GITHUB_OUTPUT}"
+          else
+            echo 'changed=true' >>"${GITHUB_OUTPUT}"
           fi
 
-          # 6. Refresh the lockfile so the branch stays `npm ci`-mergeable, then
-          #    commit both the submodule pointer and the regenerated lockfile.
+      # Refresh the lockfile so the branch stays `npm ci`-mergeable, then commit
+      # both the submodule pointer and the regenerated lockfile. The branch is
+      # new (guarded above), so a plain push cannot overwrite anyone's work.
+      - name: Commit and push the update
+        if: steps.guard.outputs.exists == 'false' && steps.detect.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
           npm install --package-lock-only --ignore-scripts
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add "${SUBMODULE_PATH}" package-lock.json
           git commit -m "Update shared package submodule to ${RELEASE_TAG}"
-          # New branch only (guarded above), so a plain push cannot overwrite work.
           retry git push --set-upstream origin "${BRANCH}"
 
-          # 7. Point a maintainer at the compare page via the job summary and a tracking issue.
+      # Organization settings prevent opening PRs automatically, so point a
+      # maintainer at the compare page via the job summary and a tracking issue.
+      - name: Open or update the tracking issue
+        if: steps.guard.outputs.exists == 'false' && steps.detect.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
           COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"
           TITLE="[Shared Package] Open PR to update submodule to ${RELEASE_TAG}"
           BODY_FILE="$(mktemp)"
@@ -158,7 +190,6 @@ jobs:
             echo "Source release: ${RELEASE_URL:-n/a}"
           } | tee -a "$GITHUB_STEP_SUMMARY" >"$BODY_FILE"
 
-          # Reuse an existing open tracking issue for this release if present.
           EXISTING="$(gh issue list --repo "$REPO" --state open \
             --search "in:title ${TITLE}" --json number,title \
             --jq "map(select(.title == \"${TITLE}\")) | .[0].number // empty" 2>/dev/null || true)"

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -165,7 +165,11 @@ jobs:
         run: |
           set -euo pipefail
           EXT_MIN="$(sed -n 's/.*minimumPythonVersion:[[:space:]]*{[[:space:]]*major:[[:space:]]*\([0-9]\+\)[[:space:]]*,[[:space:]]*minor:[[:space:]]*\([0-9]\+\).*/\1.\2/p' src/common/constants.ts | head -n1)"
-          PKG_FLOOR="$(sed -n 's/.*requires-python[^0-9]*\([0-9]\+\.[0-9]\+\).*/\1/p' "${SUBMODULE_PATH}/python/pyproject.toml" | head -n1)"
+          # Read only a >=/~= lower bound from requires-python; an upper-bound-only
+          # spec (e.g. "<3.14" or "==3.11.*") must not be misread as a floor, so
+          # leave PKG_FLOOR empty (→ warn-and-skip below) when no lower bound exists.
+          REQUIRES_PYTHON="$(sed -n 's/.*requires-python[[:space:]]*=[[:space:]]*["'\'']\([^"'\'']*\)["'\''].*/\1/p' "${SUBMODULE_PATH}/python/pyproject.toml" | head -n1)"
+          PKG_FLOOR="$(printf '%s' "${REQUIRES_PYTHON}" | grep -Eo '(>=|~=)[[:space:]]*[0-9]+\.[0-9]+' | grep -Eo '[0-9]+\.[0-9]+' | head -n1)"
           if [ -z "${PKG_FLOOR}" ]; then
             echo "::warning::Could not parse requires-python from the shared package; skipping the Python compatibility check."
           elif [ -z "${EXT_MIN}" ]; then

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -249,12 +249,15 @@ jobs:
         run: |
           set -euo pipefail
           COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"
-          TITLE="[Shared Package] Open PR to update submodule to ${RELEASE_TAG}"
+          TITLE="[Shared Package] Open PR to update submodule to v${VERSION}"
           BODY_FILE="$(mktemp)"
           {
-            echo "### Shared package submodule update ready"
+            echo "### Shared package submodule update ready for review"
             echo ''
             echo "Branch \`${BRANCH}\` has been pushed, moving \`${SUBMODULE_PATH}\` to ${RELEASE_TAG}."
+            echo ''
+            echo '> [!IMPORTANT]'
+            echo '> This branch only bumps the submodule pointer and refreshes the lockfile; it has not been built or tested by this workflow. Open the pull request and let the normal PR checks (build, lint, tests) validate it before merging.'
             echo ''
             echo 'Organization settings prevent this workflow from opening pull requests automatically. Please open it manually:'
             echo ''

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/vscode-common-python-lsp"]
+	path = external/vscode-common-python-lsp
+	url = https://github.com/microsoft/vscode-common-python-lsp.git

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,6 +2,7 @@
 .vscode-test/**
 out/**
 node_modules/**
+external/**
 src/**
 .gitignore
 .yarnrc

--- a/README.md
+++ b/README.md
@@ -118,3 +118,25 @@ In this section, you will find some common issues you might encounter and how to
 
     -   Set the `flake8.importStrategy` setting to `useBundled` and the `flake8.path` setting to point to the custom binary of Flake8 you want to use; or
     -   Install Flake8 in the selected environment.
+
+## Development
+
+This extension bundles the shared [`vscode-common-python-lsp`](https://github.com/microsoft/vscode-common-python-lsp) library as a git submodule at `external/vscode-common-python-lsp`. The submodule must be initialized before installing dependencies, because `npm install` builds the shared library from it.
+
+When cloning the repository, pull the submodule at the same time:
+
+```bash
+git clone --recurse-submodules https://github.com/microsoft/vscode-flake8.git
+```
+
+If you already cloned without `--recurse-submodules`, initialize (or update) the submodule from the repository root:
+
+```bash
+git submodule update --init --recursive
+```
+
+Then install dependencies:
+
+```bash
+npm install
+```

--- a/build/azure-devdiv-pipeline.pre-release.yml
+++ b/build/azure-devdiv-pipeline.pre-release.yml
@@ -38,6 +38,8 @@ parameters:
   - name: buildSteps
     type: stepList
     default:
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-devdiv-pipeline.stable.yml
+++ b/build/azure-devdiv-pipeline.stable.yml
@@ -33,6 +33,8 @@ parameters:
   - name: buildSteps
     type: stepList
     default:
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -48,6 +48,8 @@ extends:
           architecture: 'x64'
         displayName: Select Python version
 
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -44,6 +44,8 @@ extends:
           architecture: 'x64'
         displayName: Select Python version
 
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-pipeline.validation.yml
+++ b/build/azure-pipeline.validation.yml
@@ -32,6 +32,8 @@ parameters:
   - name: buildSteps
     type: stepList
     default:
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/postinstall.js
+++ b/build/postinstall.js
@@ -16,4 +16,28 @@ if (!existsSync(`${pkgDir}/package.json`)) {
   process.exit(0);
 }
 
+// Already built (e.g. by a prior install or the packaging pipeline); nothing to do.
+if (existsSync(`${pkgDir}/dist/index.js`)) {
+  process.exit(0);
+}
+
+// The build runs the submodule's `tsc`, which is a devDependency of the shared
+// package. A dev-pruned install (`npm ci --omit=dev`, `NODE_ENV=production`, or
+// a VSIX packager that prunes) may not have it available. Skip with guidance
+// rather than hard-failing the whole install; build/packaging jobs run a full
+// install and produce `dist/` there.
+if (
+  !existsSync(`${pkgDir}/node_modules/.bin/tsc`) &&
+  !existsSync(`${pkgDir}/node_modules/.bin/tsc.cmd`) &&
+  !existsSync(`${pkgDir}/node_modules/typescript`)
+) {
+  console.warn(
+    `[postinstall] TypeScript toolchain not installed in "${pkgDir}"; ` +
+      "skipping the shared package build. Run " +
+      `\`npm --prefix ${pkgDir} install && npm --prefix ${pkgDir} run build\` ` +
+      "if you need dist/ locally.",
+  );
+  process.exit(0);
+}
+
 execSync(`npm --prefix ${pkgDir} run build`, { stdio: "inherit" });

--- a/build/postinstall.js
+++ b/build/postinstall.js
@@ -1,0 +1,19 @@
+// Builds the shared package that lives in the git submodule after install.
+//
+// The build is skipped (with guidance) when the submodule has not been
+// checked out, so a clone made without `--recurse-submodules` does not fail
+// `npm install`/`npm ci` at the postinstall step with a confusing error.
+const { existsSync } = require("fs");
+const { execSync } = require("child_process");
+
+const pkgDir = "external/vscode-common-python-lsp/typescript";
+
+if (!existsSync(`${pkgDir}/package.json`)) {
+  console.warn(
+    `[postinstall] Shared package submodule not found at "${pkgDir}". ` +
+      "Run `git submodule update --init --recursive` and reinstall to build it.",
+  );
+  process.exit(0);
+}
+
+execSync(`npm --prefix ${pkgDir} run build`, { stdio: "inherit" });

--- a/build/postinstall.js
+++ b/build/postinstall.js
@@ -1,8 +1,11 @@
 // Builds the shared package that lives in the git submodule after install.
 //
-// The build is skipped (with guidance) when the submodule has not been
-// checked out, so a clone made without `--recurse-submodules` does not fail
-// `npm install`/`npm ci` at the postinstall step with a confusing error.
+// Note: a clone made without `--recurse-submodules` actually fails earlier,
+// when npm resolves the `file:` dependency during the install phase, before
+// this postinstall script runs. The guard below only adds a friendlier message
+// on the rarer paths that still reach postinstall (e.g. the submodule was
+// removed after a prior install); it is not a substitute for initializing the
+// submodule.
 const { existsSync } = require("fs");
 const { execSync } = require("child_process");
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -110,6 +110,16 @@ def install_bundled_libs(session):
     """Installs the libraries that will be bundled with the extension."""
     session.install("wheel")
     _install_bundle(session)
+    # Source the shared Python library from the git submodule instead of the
+    # published package so the bundled copy matches the pinned submodule commit.
+    session.install(
+        "-t",
+        "./bundled/libs",
+        "--no-cache-dir",
+        "--no-deps",
+        "--upgrade",
+        "./external/vscode-common-python-lsp/python",
+    )
 
 
 @nox.session(python="3.10")

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,6 +112,12 @@ def install_bundled_libs(session):
     _install_bundle(session)
     # Source the shared Python library from the git submodule instead of the
     # published package so the bundled copy matches the pinned submodule commit.
+    shared_python_lib = pathlib.Path("external/vscode-common-python-lsp/python")
+    if not shared_python_lib.exists():
+        session.error(
+            f"Shared package submodule missing at {shared_python_lib}. "
+            "Run 'git submodule update --init --recursive' before building."
+        )
     session.install(
         "-t",
         "./bundled/libs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,10 @@
         "": {
             "name": "flake8",
             "version": "2026.7.0-dev",
+            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "^0.6.0",
+                "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
                 "@vscode/python-extension": "^1.0.6",
                 "vscode-languageclient": "^8.1.0"
             },
@@ -39,6 +40,81 @@
             },
             "engines": {
                 "vscode": "^1.74.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript": {
+            "name": "@vscode/common-python-lsp",
+            "version": "0.8.0",
+            "license": "MIT",
+            "dependencies": {
+                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
+                "@vscode/python-extension": "^1.0.6",
+                "dotenv": "^17.4.1",
+                "fs-extra": "^11.3.4",
+                "semver": "^7.7.4",
+                "vscode-languageclient": "^8.1.0"
+            },
+            "devDependencies": {
+                "@types/chai": "^5.2.3",
+                "@types/fs-extra": "^11.0.4",
+                "@types/mocha": "^10.0.10",
+                "@types/node": "22.x",
+                "@types/semver": "^7.7.1",
+                "@types/sinon": "^21.0.0",
+                "@types/vscode": "^1.74.0",
+                "@typescript-eslint/eslint-plugin": "^7.18.0",
+                "@typescript-eslint/parser": "^7.18.0",
+                "chai": "^6.2.2",
+                "eslint": "^8.57.1",
+                "mocha": "^11.7.5",
+                "prettier": "^3.8.1",
+                "sinon": "^22.0.0",
+                "typescript": "^6.0.3"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "vscode": "^1.74.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/diff": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+            "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/sinon": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
+            "integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1",
+                "@sinonjs/fake-timers": "^15.4.0",
+                "@sinonjs/samsam": "^10.0.2",
+                "diff": "^9.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/sinon"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/@azu/format-text": {
@@ -742,9 +818,9 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
-            "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -970,6 +1046,13 @@
             "version": "2.1.7",
             "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
             "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
             "dev": true,
             "license": "MIT"
         },
@@ -1214,22 +1297,8 @@
             "license": "ISC"
         },
         "node_modules/@vscode/common-python-lsp": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.6.0.tgz",
-            "integrity": "sha512-wabQS/YK4qlZtU2/e2JrdvuuwyjVfvoPayCcpv3n+3Ii7+4yumrP6vZo/4zsnTUlapBzckOiSyGuwA5oODJGdg==",
-            "license": "MIT",
-            "dependencies": {
-                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
-                "@vscode/python-extension": "^1.0.6",
-                "dotenv": "^17.4.1",
-                "fs-extra": "^11.3.4",
-                "semver": "^7.7.4",
-                "vscode-languageclient": "^8.1.0"
-            },
-            "engines": {
-                "node": ">=18.0.0",
-                "vscode": "^1.74.0"
-            }
+            "resolved": "external/vscode-common-python-lsp/typescript",
+            "link": true
         },
         "node_modules/@vscode/python-environments": {
             "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         },
         "external/vscode-common-python-lsp/typescript": {
             "name": "@vscode/common-python-lsp",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "license": "MIT",
             "dependencies": {
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "main": "./dist/extension.js",
     "l10n": "./l10n",
     "scripts": {
-        "postinstall": "npm --prefix external/vscode-common-python-lsp/typescript run build",
+        "postinstall": "node ./build/postinstall.js",
         "vscode:prepublish": "npm run package",
         "compile": "webpack",
         "watch": "webpack --watch",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "main": "./dist/extension.js",
     "l10n": "./l10n",
     "scripts": {
+        "postinstall": "npm --prefix external/vscode-common-python-lsp/typescript run build",
         "vscode:prepublish": "npm run package",
         "compile": "webpack",
         "watch": "webpack --watch",
@@ -226,7 +227,7 @@
         ]
     },
     "dependencies": {
-        "@vscode/common-python-lsp": "^0.6.0",
+        "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
         "@vscode/python-extension": "^1.0.6",
         "vscode-languageclient": "^8.1.0"
     },

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,3 @@
 pygls
 packaging
 flake8
-vscode-common-python-lsp==0.6.0

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,10 @@
 # Run following command:
 # uv pip compile --generate-hashes --upgrade ./requirements.in > .\requirements.txt
 
+# NOTE: pygls and packaging are also runtime dependencies of the bundled shared
+# package (external/vscode-common-python-lsp), which is installed with --no-deps.
+# Keep them pinned here so the submodule's Python lib stays installable.
+# lsprotocol is pulled in transitively via pygls.
 pygls
 packaging
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,3 @@ typing-extensions==4.15.0 \
     # via
     #   cattrs
     #   exceptiongroup
-vscode-common-python-lsp==0.6.0 \
-    --hash=sha256:499bf066372ed86a62f140a668a4b0f72328cdf8d08057df45892fc1c5b627f6 \
-    --hash=sha256:6892a401311217f501d9b2f86a82a9629c89d565082330adb77bf8cddf634a72
-    # via -r ./requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ lsprotocol==2025.0.0 \
     --hash=sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7
     # via
     #   pygls
-    #   vscode-common-python-lsp
 mccabe==0.7.0 \
     --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325 \
     --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e
@@ -36,7 +35,6 @@ packaging==26.0 \
     --hash=sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529
     # via
     #   -r ./requirements.in
-    #   vscode-common-python-lsp
 pycodestyle==2.14.0 \
     --hash=sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783 \
     --hash=sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d
@@ -50,7 +48,6 @@ pygls==2.0.1 \
     --hash=sha256:d29748042cea5bedc98285eb3e2c0c60bf3fc73786319519001bf72bbe8f36cc
     # via
     #   -r ./requirements.in
-    #   vscode-common-python-lsp
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,7 @@
         "noImplicitReturns": true, 
         "noFallthroughCasesInSwitch": true, 
         "noUnusedParameters": true
-    }
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", "external", "out", "dist", ".vscode-test"]
 }


### PR DESCRIPTION
## Summary

Consumes the shared LSP package (`vscode-common-python-lsp`) as a **git submodule** pinned to a release tag, instead of the published npm/PyPI packages, and keeps that submodule updated via a `repository_dispatch` event from `vscode-common-python-lsp` rather than Dependabot.

### 1. Git submodule
- Adds `external/vscode-common-python-lsp` (`.gitmodules`) pinned to a shared-package release tag.
- **TypeScript:** `package.json` sources it via `"@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript"`; `build/postinstall.js` builds the submodule's TS output on install (skips when already built or when the submodule toolchain is absent).
- **Python:** `noxfile.py` installs `./external/vscode-common-python-lsp/python` into `./bundled/libs` with `--no-deps --upgrade`, so the bundled copy matches the pinned submodule commit.

### 2. New `.github/workflows/shared-package-submodule-sync.yml`
Handles the `shared-package-release` `repository_dispatch`: branches off `main`, advances the submodule pointer to the released tag, refreshes the npm lockfile, verifies the pinned tag and the Python `requires-python` floor, then **pushes the branch and opens a tracking issue** with a manual compare/PR link (org settings prevent the workflow from opening PRs automatically).

### 3. `.github/dependabot.yml`
Moves the shared package into the npm and pip `ignore` lists so Dependabot no longer opens duplicate update PRs for it.
