### PR TITLE
Experiment: integrate shared package as a git submodule

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Build VSIX
         uses: ./.github/actions/build-vsix
@@ -31,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Lint
         uses: ./.github/actions/lint
@@ -54,6 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       # Install bundled libs using env.PYTHON_VERSION even though you test it on other versions.
@@ -106,6 +111,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       - name: Use Node.js ${{ env.NODE_VERSION }}

--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Build VSIX
         uses: ./.github/actions/build-vsix
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Lint
         uses: ./.github/actions/lint
@@ -62,6 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       # Install bundled libs using env.PYTHON_VERSION even though you test it on other versions.
@@ -115,6 +120,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           path: ${{ env.special-working-directory-relative }}
 
       - name: Install Node

--- a/.github/workflows/shared-package-submodule-sync.yml
+++ b/.github/workflows/shared-package-submodule-sync.yml
@@ -1,4 +1,4 @@
-name: Shared Package Release Handler
+name: Shared Package Submodule Sync
 
 on:
   repository_dispatch:
@@ -9,32 +9,22 @@ permissions:
   issues: write
 
 concurrency:
-  group: 'shared-package-release-${{ github.event.client_payload.release_tag }}'
+  group: 'shared-package-submodule-${{ github.event.client_payload.release_tag }}'
   cancel-in-progress: false
 
 env:
-  NODE_VERSION: 24.17.0
-  # Match the Python version documented in requirements.in so the regenerated
-  # lockfile stays valid across the supported Python range.
-  PYTHON_VERSION: '3.9'
+  SUBMODULE_PATH: external/vscode-common-python-lsp
 
 jobs:
-  update-shared-packages:
-    name: Update shared packages
+  update-submodule:
+    name: Update shared package submodule
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Install Node
-        uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          submodules: recursive
+          fetch-depth: 0
 
       - name: Validate dispatch payload
         env:
@@ -50,15 +40,6 @@ jobs:
             exit 1
           fi
 
-      - name: Normalize release tag
-        id: release_version
-        env:
-          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
-        run: |
-          set -euo pipefail
-          VERSION="${RELEASE_TAG#v}"
-          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Create branch for this release
         env:
           RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
@@ -69,46 +50,28 @@ jobs:
           # Fetch any pre-existing remote branch so --force-with-lease has a ref.
           git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
           git checkout -B "$BRANCH" origin/main
+          # Re-sync the submodule to whatever the freshly checked-out main records.
+          git submodule update --init --recursive "${SUBMODULE_PATH}"
 
-      - name: Update npm dependency
+      - name: Move submodule to the released commit
         env:
-          NPM_DEP: ${{ github.event.client_payload.npm_dependency }}
-          RELEASE_VERSION: ${{ steps.release_version.outputs.value }}
+          RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
         run: |
           set -euo pipefail
-          if [ -z "${NPM_DEP}" ]; then
-            echo 'No npm dependency in payload; skipping.'
-            exit 0
+          cd "${SUBMODULE_PATH}"
+          git fetch --tags --force origin
+          STRIPPED="${RELEASE_TAG#v}"
+          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}^{commit}" >/dev/null; then
+            TARGET="refs/tags/${RELEASE_TAG}"
+          elif git rev-parse -q --verify "refs/tags/v${STRIPPED}^{commit}" >/dev/null; then
+            TARGET="refs/tags/v${STRIPPED}"
+          else
+            echo "Release tag '${RELEASE_TAG}' not found upstream; falling back to origin/main." >&2
+            git fetch origin main
+            TARGET="origin/main"
           fi
-          npm install "${NPM_DEP}@${RELEASE_VERSION}"
-
-      - name: Update pip dependency
-        env:
-          PIP_DEP: ${{ github.event.client_payload.pip_dependency }}
-          RELEASE_VERSION: ${{ steps.release_version.outputs.value }}
-        run: |
-          set -euo pipefail
-          if [ -z "${PIP_DEP}" ]; then
-            echo 'No pip dependency in payload; skipping.'
-            exit 0
-          fi
-          if [ ! -f requirements.in ]; then
-            echo 'No requirements.in found; skipping.'
-            exit 0
-          fi
-          python -m pip install --upgrade uv
-          # Rewrite the pin (case-insensitive) for the shared package only.
-          sed -i -E "s/^${PIP_DEP}([<>=!~].*)?\$/${PIP_DEP}==${RELEASE_VERSION}/I" requirements.in
-          if ! grep -iEq "^${PIP_DEP}==${RELEASE_VERSION}([[:space:];].*)?\$" requirements.in; then
-            echo "Failed to pin ${PIP_DEP}==${RELEASE_VERSION} in requirements.in." >&2
-            exit 1
-          fi
-          # Scope the re-resolve to the shared package and pin to the documented
-          # Python version so unrelated deps and version markers are preserved.
-          uv pip compile --generate-hashes \
-            --upgrade-package "${PIP_DEP}" \
-            --python-version "${PYTHON_VERSION}" \
-            -o requirements.txt requirements.in
+          echo "Checking out submodule at ${TARGET}."
+          git checkout --detach "${TARGET}"
 
       - name: Push branch and open tracking issue if changed
         env:
@@ -120,18 +83,19 @@ jobs:
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          if git diff --quiet; then
-            echo 'No changes detected.'
+          # Only the submodule gitlink should have moved.
+          if git diff --quiet -- "${SUBMODULE_PATH}"; then
+            echo 'Submodule already at the released commit; nothing to do.'
             exit 0
           fi
           BRANCH="shared-package-v${RELEASE_TAG#v}"
-          git add -A
-          git commit -m "Upgrade shared package to ${RELEASE_TAG}"
+          git add "${SUBMODULE_PATH}"
+          git commit -m "Update shared package submodule to ${RELEASE_TAG}"
           git push --force-with-lease --set-upstream origin "$BRANCH"
           COMPARE_URL="https://github.com/${REPO}/compare/main...${BRANCH}?expand=1"
-          TITLE="[Shared Package] Open PR to upgrade to ${RELEASE_TAG}"
+          TITLE="[Shared Package] Open PR to update submodule to ${RELEASE_TAG}"
           {
-            echo "### Shared package upgrade ready"
+            echo "### Shared package submodule update ready"
             echo ''
             echo "Branch \`${BRANCH}\` has been pushed."
             echo ''
@@ -141,7 +105,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           BODY_FILE="$(mktemp)"
           cat > "$BODY_FILE" <<EOF
-          Branch \`${BRANCH}\` has been pushed with the shared package upgrade to ${RELEASE_TAG}.
+          Branch \`${BRANCH}\` has been pushed, moving the \`${SUBMODULE_PATH}\` submodule to ${RELEASE_TAG}.
 
           Organization settings prevent this workflow from opening pull requests automatically. Please open the PR manually:
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/vscode-common-python-lsp"]
+	path = external/vscode-common-python-lsp
+	url = https://github.com/microsoft/vscode-common-python-lsp.git

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,6 +2,7 @@
 .vscode-test/**
 out/**
 node_modules/**
+external/**
 src/**
 .gitignore
 .yarnrc

--- a/build/azure-devdiv-pipeline.pre-release.yml
+++ b/build/azure-devdiv-pipeline.pre-release.yml
@@ -38,6 +38,8 @@ parameters:
   - name: buildSteps
     type: stepList
     default:
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-devdiv-pipeline.stable.yml
+++ b/build/azure-devdiv-pipeline.stable.yml
@@ -33,6 +33,8 @@ parameters:
   - name: buildSteps
     type: stepList
     default:
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -48,6 +48,8 @@ extends:
           architecture: 'x64'
         displayName: Select Python version
 
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -44,6 +44,8 @@ extends:
           architecture: 'x64'
         displayName: Select Python version
 
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/build/azure-pipeline.validation.yml
+++ b/build/azure-pipeline.validation.yml
@@ -32,6 +32,8 @@ parameters:
   - name: buildSteps
     type: stepList
     default:
+      - script: git submodule update --init --recursive
+        displayName: Checkout submodules
       - script: npm ci
         displayName: Install NPM dependencies
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -110,6 +110,16 @@ def install_bundled_libs(session):
     """Installs the libraries that will be bundled with the extension."""
     session.install("wheel")
     _install_bundle(session)
+    # Source the shared Python library from the git submodule instead of the
+    # published package so the bundled copy matches the pinned submodule commit.
+    session.install(
+        "-t",
+        "./bundled/libs",
+        "--no-cache-dir",
+        "--no-deps",
+        "--upgrade",
+        "./external/vscode-common-python-lsp/python",
+    )
 
 
 @nox.session(python="3.10")

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,10 @@
         "": {
             "name": "flake8",
             "version": "2026.7.0-dev",
+            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "^0.6.0",
+                "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
                 "@vscode/python-extension": "^1.0.6",
                 "vscode-languageclient": "^8.1.0"
             },
@@ -39,6 +40,81 @@
             },
             "engines": {
                 "vscode": "^1.74.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript": {
+            "name": "@vscode/common-python-lsp",
+            "version": "0.8.0",
+            "license": "MIT",
+            "dependencies": {
+                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
+                "@vscode/python-extension": "^1.0.6",
+                "dotenv": "^17.4.1",
+                "fs-extra": "^11.3.4",
+                "semver": "^7.7.4",
+                "vscode-languageclient": "^8.1.0"
+            },
+            "devDependencies": {
+                "@types/chai": "^5.2.3",
+                "@types/fs-extra": "^11.0.4",
+                "@types/mocha": "^10.0.10",
+                "@types/node": "22.x",
+                "@types/semver": "^7.7.1",
+                "@types/sinon": "^21.0.0",
+                "@types/vscode": "^1.74.0",
+                "@typescript-eslint/eslint-plugin": "^7.18.0",
+                "@typescript-eslint/parser": "^7.18.0",
+                "chai": "^6.2.2",
+                "eslint": "^8.57.1",
+                "mocha": "^11.7.5",
+                "prettier": "^3.8.1",
+                "sinon": "^22.0.0",
+                "typescript": "^6.0.3"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "vscode": "^1.74.0"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/diff": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+            "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/sinon": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
+            "integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1",
+                "@sinonjs/fake-timers": "^15.4.0",
+                "@sinonjs/samsam": "^10.0.2",
+                "diff": "^9.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/sinon"
+            }
+        },
+        "external/vscode-common-python-lsp/typescript/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/@azu/format-text": {
@@ -742,9 +818,9 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
-            "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -970,6 +1046,13 @@
             "version": "2.1.7",
             "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
             "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
             "dev": true,
             "license": "MIT"
         },
@@ -1214,22 +1297,8 @@
             "license": "ISC"
         },
         "node_modules/@vscode/common-python-lsp": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.6.0.tgz",
-            "integrity": "sha512-wabQS/YK4qlZtU2/e2JrdvuuwyjVfvoPayCcpv3n+3Ii7+4yumrP6vZo/4zsnTUlapBzckOiSyGuwA5oODJGdg==",
-            "license": "MIT",
-            "dependencies": {
-                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
-                "@vscode/python-extension": "^1.0.6",
-                "dotenv": "^17.4.1",
-                "fs-extra": "^11.3.4",
-                "semver": "^7.7.4",
-                "vscode-languageclient": "^8.1.0"
-            },
-            "engines": {
-                "node": ">=18.0.0",
-                "vscode": "^1.74.0"
-            }
+            "resolved": "external/vscode-common-python-lsp/typescript",
+            "link": true
         },
         "node_modules/@vscode/python-environments": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "main": "./dist/extension.js",
     "l10n": "./l10n",
     "scripts": {
+        "postinstall": "npm --prefix external/vscode-common-python-lsp/typescript run build",
         "vscode:prepublish": "npm run package",
         "compile": "webpack",
         "watch": "webpack --watch",

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
         ]
     },
     "dependencies": {
-        "@vscode/common-python-lsp": "^0.6.0",
+        "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
         "@vscode/python-extension": "^1.0.6",
         "vscode-languageclient": "^8.1.0"
     },

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,3 @@
 pygls
 packaging
 flake8
-vscode-common-python-lsp==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,3 @@ typing-extensions==4.15.0 \
     # via
     #   cattrs
     #   exceptiongroup
-vscode-common-python-lsp==0.6.0 \
-    --hash=sha256:499bf066372ed86a62f140a668a4b0f72328cdf8d08057df45892fc1c5b627f6 \
-    --hash=sha256:6892a401311217f501d9b2f86a82a9629c89d565082330adb77bf8cddf634a72
-    # via -r ./requirements.in

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,7 @@
         "noImplicitReturns": true, 
         "noFallthroughCasesInSwitch": true, 
         "noUnusedParameters": true
-    }
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", "external", "out", "dist", ".vscode-test"]
 }


### PR DESCRIPTION
**Experiment:** integrate the shared package as a git submodule instead of an external published dependency.

This PR targets `shared-package-sync` so the diff isolates the submodule conversion on top of that branch.

### Changes
- Add `external/vscode-common-python-lsp` as a git submodule, pinned to `v0.8.0`.
- `package.json`: `@vscode/common-python-lsp` -> `file:external/vscode-common-python-lsp/typescript`.
- `noxfile.py`: bundle the Python lib from `./external/vscode-common-python-lsp/python` (`--no-deps`).
- `requirements.in` / `requirements.txt`: drop the `vscode-common-python-lsp` pin and hash block (now sourced from the submodule).
- Replace `shared-package-release.yml` (version bump) with `shared-package-submodule-sync.yml` (bumps the submodule commit to the released tag, pushes a branch, opens a tracking issue with a manual-PR link).

### Notes / caveats
- CI must check out submodules (`submodules: recursive`) and build the TS submodule (`dist/`) before packaging — the `file:` install does not run a `prepare` build.
- `--generate-hashes` cannot hash a local path, so the shared Python lib is intentionally out of the hashed lockfile and installed via the submodule.