### PR TITLE
Respect 10-day dependency cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 10
     groups:
       npm-minor-patch:
         patterns:
@@ -31,6 +33,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 10
     open-pull-requests-limit: 10
     groups:
       pip-minor-patch:
@@ -49,6 +53,8 @@ updates:
     directory: '/src/test/python_tests'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 10
     open-pull-requests-limit: 10
     groups:
       pip-test-minor-patch:


### PR DESCRIPTION
## Summary

- require npm dependency versions to age for 10 days before Dependabot proposes version updates
- require pip dependency versions, including test dependencies, to age for 10 days
- leave security updates and other package ecosystems unchanged

This aligns Dependabot version updates with Microsoft's npm and pip proxy cooldown period without coupling public repositories to internal registry configuration.