### PR TITLE
Remove dependencies provided by shared package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ multi-ecosystem-groups:
   dependencies:
     schedule:
       interval: 'weekly'
-    exclude-patterns:
-      - 'flake8'
     labels:
       - 'dependencies'
       - 'debt'
@@ -38,6 +36,8 @@ updates:
       - '/src/test/python_tests'
     patterns:
       - '*'
+    exclude-patterns:
+      - 'flake8'
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,10 +34,28 @@ updates:
     directories:
       - '/'
       - '/src/test/python_tests'
+    # Multi-ecosystem groups only support positive patterns. Keep Flake8
+    # unmatched so its updates remain standalone.
     patterns:
-      - '*'
-    exclude-patterns:
-      - 'flake8'
+      - 'attrs'
+      - 'cattrs'
+      - 'colorama'
+      - 'exceptiongroup'
+      - 'iniconfig'
+      - 'lsprotocol'
+      - 'mccabe'
+      - 'packaging'
+      - 'pluggy'
+      - 'pycodestyle'
+      - 'pyflakes'
+      - 'pygls'
+      - 'pygments'
+      - 'pyhamcrest'
+      - 'pytest'
+      - 'python-jsonrpc-server'
+      - 'tomli'
+      - 'typing-extensions'
+      - 'ujson'
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ multi-ecosystem-groups:
   dependencies:
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'debt'
@@ -22,7 +23,6 @@ updates:
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
     ignore:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'
@@ -59,7 +59,6 @@ updates:
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
 
   # The shared package submodule is updated daily in a standalone PR.
   - package-ecosystem: 'gitsubmodule'
@@ -83,4 +82,3 @@ updates:
     patterns:
       - '*'
     multi-ecosystem-group: 'dependencies'
-    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,6 @@ updates:
     ignore:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'
-      - dependency-name: 'vscode-languageclient'
 
   - package-ecosystem: 'pip'
     labels:

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,7 +60,6 @@ def _get_package_data(package):
 
 def _update_npm_packages(session: nox.Session) -> None:
     pinned = {
-        "vscode-languageclient",
         "@types/vscode",
         "@types/node",
         "@vscode/common-python-lsp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
-                "@vscode/python-extension": "^1.0.6",
-                "vscode-languageclient": "^8.1.0"
+                "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript"
             },
             "devDependencies": {
                 "@types/chai": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -227,9 +227,7 @@
         ]
     },
     "dependencies": {
-        "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
-        "@vscode/python-extension": "^1.0.6",
-        "vscode-languageclient": "^8.1.0"
+        "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript"
     },
     "devDependencies": {
         "@types/chai": "^5.2.3",


### PR DESCRIPTION
## Summary  - remove extension-level npm dependencies already provided by `@vscode/common-python-lsp`  - keep dependencies still imported by extension-owned source or tests - remove stale dependency-update exclusions where the shared package now owns the dependency   ## Dependabot configuration  - use supported positive `patterns` to group all currently locked non-tool Python dependencies - leave the primary tool unmatched so its updates remain standalone 
- set the pull request limit on the multi-ecosystem group, as required by Dependabot's schema