### PR TITLE
Use approved npm feed for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 
+registries:
+  pylance-public-packages:
+    type: npm-registry
+    url: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Pylance_PublicPackages/npm/registry/
+    tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+    client-id: 92c669e8-02ad-4ce6-ad73-f222fc7177e2
+    replaces-base: true
+
 multi-ecosystem-groups:
   dependencies:
     schedule:
@@ -13,6 +21,7 @@ multi-ecosystem-groups:
 updates:
   # NPM, Python, and GitHub Actions dependencies are updated together.
   - package-ecosystem: 'npm'
+    registries: '*'
     labels:
       - 'dependencies'
       - 'debt'
@@ -21,8 +30,6 @@ updates:
     patterns:
       - '*'
     multi-ecosystem-group: 'dependencies'
-    cooldown:
-      default-days: 7
     ignore:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,8 @@ multi-ecosystem-groups:
 updates:
   # NPM, Python, and GitHub Actions dependencies are updated together.
   - package-ecosystem: 'npm'
-    registries: '*'
+    registries:
+      - 'pylance-public-packages'
     labels:
       - 'dependencies'
       - 'debt'
@@ -30,6 +31,8 @@ updates:
     patterns:
       - '*'
     multi-ecosystem-group: 'dependencies'
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-registry=https://registry.npmjs.org/
-# Do not require auth for public installs
-always-auth=false


### PR DESCRIPTION
## Summary  - configure Dependabot npm updates to use the team-owned `Pylance_PublicPackages` Azure Artifacts feed - authenticate with Azure OIDC using the identity pattern established by microsoft/pyrx#9310 - retain the seven-day npm cooldown because `@vscode/python-environments` still uses an explicit feed URL that `replaces-base` cannot redirect - retain the seven-day pip cooldown until an approved Python-feed path is confirmed - remove the project `.npmrc` that forced Dependabot back to public npm  ## Required infrastructure  Do not remove `no-merge` until the managed identity has feed access and a Dependabot federated credential for this repository. The credential must use issuer `https://token.actions.msft.ghe.com`, audience `api://AzureADTokenExchange`, and the exact repository subject emitted by Dependabot.  The tenant and client IDs are identifiers, not secrets.